### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.0.0 - 2025-06-20
+
+### Changed (4)
+
+- Made the `count` field required in `WebsocketApiRateLimit`.
+- Corrected parameter naming to use camelCase instead of snake_case.
+- Resolved floating-point precision issues.
+- Fixed serialization of reserved keywords (e.g., `r#type`) so the `r#` prefix is no longer included.
+
 ## 3.0.0 - 2025-06-19
 
 ### Changed (2)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binance-sdk"
-version = "3.0.0"
+version = "4.0.0"
 authors = [ "Binance" ]
 edition = "2024"
 resolver = "3"
@@ -64,6 +64,7 @@ futures = "0.3"
 http = "1"
 tracing = "0.1"
 once_cell = "1.21"
+rust_decimal = "1.37.2"
 
   [dependencies.serde]
   version = "^1.0"

--- a/src/algo/rest_api/apis/future_algo_api.rs
+++ b/src/algo/rest_api/apis/future_algo_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -117,9 +118,6 @@ pub struct QueryCurrentAlgoOpenOrdersFutureAlgoParams {
 impl QueryCurrentAlgoOpenOrdersFutureAlgoParams {
     /// Create a builder for [`query_current_algo_open_orders_future_algo`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryCurrentAlgoOpenOrdersFutureAlgoParamsBuilder {
         QueryCurrentAlgoOpenOrdersFutureAlgoParamsBuilder::default()
@@ -172,9 +170,6 @@ pub struct QueryHistoricalAlgoOrdersFutureAlgoParams {
 
 impl QueryHistoricalAlgoOrdersFutureAlgoParams {
     /// Create a builder for [`query_historical_algo_orders_future_algo`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryHistoricalAlgoOrdersFutureAlgoParamsBuilder {
@@ -398,7 +393,7 @@ impl FutureAlgoApi for FutureAlgoApiClient {
         query_params.insert("algoId".to_string(), json!(algo_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelAlgoOrderFutureAlgoResponse>(
@@ -425,7 +420,7 @@ impl FutureAlgoApi for FutureAlgoApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCurrentAlgoOpenOrdersFutureAlgoResponse>(
@@ -468,11 +463,11 @@ impl FutureAlgoApi for FutureAlgoApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -480,11 +475,11 @@ impl FutureAlgoApi for FutureAlgoApiClient {
         }
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryHistoricalAlgoOrdersFutureAlgoResponse>(
@@ -522,11 +517,11 @@ impl FutureAlgoApi for FutureAlgoApiClient {
         }
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QuerySubOrdersFutureAlgoResponse>(
@@ -566,28 +561,30 @@ impl FutureAlgoApi for FutureAlgoApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
         query_params.insert("duration".to_string(), json!(duration));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = client_algo_id {
-            query_params.insert("client_algo_id".to_string(), json!(rw));
+            query_params.insert("clientAlgoId".to_string(), json!(rw));
         }
 
         if let Some(rw) = reduce_only {
-            query_params.insert("reduce_only".to_string(), json!(rw));
+            query_params.insert("reduceOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_price {
-            query_params.insert("limit_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("limitPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::TimeWeightedAveragePriceFutureAlgoResponse>(
@@ -627,28 +624,30 @@ impl FutureAlgoApi for FutureAlgoApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
         query_params.insert("urgency".to_string(), json!(urgency));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = client_algo_id {
-            query_params.insert("client_algo_id".to_string(), json!(rw));
+            query_params.insert("clientAlgoId".to_string(), json!(rw));
         }
 
         if let Some(rw) = reduce_only {
-            query_params.insert("reduce_only".to_string(), json!(rw));
+            query_params.insert("reduceOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_price {
-            query_params.insert("limit_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("limitPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::VolumeParticipationFutureAlgoResponse>(

--- a/src/algo/rest_api/apis/spot_algo_api.rs
+++ b/src/algo/rest_api/apis/spot_algo_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -113,9 +114,6 @@ pub struct QueryCurrentAlgoOpenOrdersSpotAlgoParams {
 impl QueryCurrentAlgoOpenOrdersSpotAlgoParams {
     /// Create a builder for [`query_current_algo_open_orders_spot_algo`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryCurrentAlgoOpenOrdersSpotAlgoParamsBuilder {
         QueryCurrentAlgoOpenOrdersSpotAlgoParamsBuilder::default()
@@ -168,9 +166,6 @@ pub struct QueryHistoricalAlgoOrdersSpotAlgoParams {
 
 impl QueryHistoricalAlgoOrdersSpotAlgoParams {
     /// Create a builder for [`query_historical_algo_orders_spot_algo`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryHistoricalAlgoOrdersSpotAlgoParamsBuilder {
@@ -299,7 +294,7 @@ impl SpotAlgoApi for SpotAlgoApiClient {
         query_params.insert("algoId".to_string(), json!(algo_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelAlgoOrderSpotAlgoResponse>(
@@ -326,7 +321,7 @@ impl SpotAlgoApi for SpotAlgoApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCurrentAlgoOpenOrdersSpotAlgoResponse>(
@@ -369,11 +364,11 @@ impl SpotAlgoApi for SpotAlgoApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -381,11 +376,11 @@ impl SpotAlgoApi for SpotAlgoApiClient {
         }
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryHistoricalAlgoOrdersSpotAlgoResponse>(
@@ -423,11 +418,11 @@ impl SpotAlgoApi for SpotAlgoApiClient {
         }
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QuerySubOrdersSpotAlgoResponse>(
@@ -464,16 +459,18 @@ impl SpotAlgoApi for SpotAlgoApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
         query_params.insert("duration".to_string(), json!(duration));
 
         if let Some(rw) = client_algo_id {
-            query_params.insert("client_algo_id".to_string(), json!(rw));
+            query_params.insert("clientAlgoId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_price {
-            query_params.insert("limit_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("limitPrice".to_string(), json!(rw));
         }
 
         send_request::<models::TimeWeightedAveragePriceSpotAlgoResponse>(

--- a/src/c2c/rest_api/apis/c2_c_api.rs
+++ b/src/c2c/rest_api/apis/c2_c_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -82,9 +83,6 @@ pub struct GetC2CTradeHistoryParams {
 impl GetC2CTradeHistoryParams {
     /// Create a builder for [`get_c2_c_trade_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetC2CTradeHistoryParamsBuilder {
         GetC2CTradeHistoryParamsBuilder::default()
@@ -107,11 +105,11 @@ impl C2CApi for C2CApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -119,7 +117,7 @@ impl C2CApi for C2CApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetC2CTradeHistoryResponse>(

--- a/src/common/models.rs
+++ b/src/common/models.rs
@@ -115,7 +115,8 @@ pub struct WebsocketApiRateLimit {
     #[serde(rename = "intervalNum")]
     pub interval_num: u32,
     pub limit: u32,
-    pub count: Option<u32>,
+    #[serde(default)]
+    pub count: u32,
 }
 
 #[derive(Debug)]

--- a/src/convert/rest_api/apis/market_data_api.rs
+++ b/src/convert/rest_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -75,9 +76,6 @@ pub struct ListAllConvertPairsParams {
 impl ListAllConvertPairsParams {
     /// Create a builder for [`list_all_convert_pairs`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> ListAllConvertPairsParamsBuilder {
         ListAllConvertPairsParamsBuilder::default()
@@ -100,9 +98,6 @@ pub struct QueryOrderQuantityPrecisionPerAssetParams {
 impl QueryOrderQuantityPrecisionPerAssetParams {
     /// Create a builder for [`query_order_quantity_precision_per_asset`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryOrderQuantityPrecisionPerAssetParamsBuilder {
         QueryOrderQuantityPrecisionPerAssetParamsBuilder::default()
@@ -123,11 +118,11 @@ impl MarketDataApi for MarketDataApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = from_asset {
-            query_params.insert("from_asset".to_string(), json!(rw));
+            query_params.insert("fromAsset".to_string(), json!(rw));
         }
 
         if let Some(rw) = to_asset {
-            query_params.insert("to_asset".to_string(), json!(rw));
+            query_params.insert("toAsset".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::ListAllConvertPairsResponseInner>>(
@@ -156,7 +151,7 @@ impl MarketDataApi for MarketDataApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryOrderQuantityPrecisionPerAssetResponseInner>>(

--- a/src/convert/rest_api/apis/trade_api.rs
+++ b/src/convert/rest_api/apis/trade_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -202,9 +203,6 @@ pub struct OrderStatusParams {
 impl OrderStatusParams {
     /// Create a builder for [`order_status`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> OrderStatusParamsBuilder {
         OrderStatusParamsBuilder::default()
@@ -308,9 +306,6 @@ pub struct QueryLimitOpenOrdersParams {
 impl QueryLimitOpenOrdersParams {
     /// Create a builder for [`query_limit_open_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryLimitOpenOrdersParamsBuilder {
         QueryLimitOpenOrdersParamsBuilder::default()
@@ -394,7 +389,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("quoteId".to_string(), json!(quote_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AcceptQuoteResponse>(
@@ -426,7 +421,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("orderId".to_string(), json!(order_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelLimitOrderResponse>(
@@ -466,7 +461,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetConvertTradeHistoryResponse>(
@@ -493,11 +488,11 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = quote_id {
-            query_params.insert("quote_id".to_string(), json!(rw));
+            query_params.insert("quoteId".to_string(), json!(rw));
         }
 
         send_request::<models::OrderStatusResponse>(
@@ -537,26 +532,29 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("quoteAsset".to_string(), json!(quote_asset));
 
-        query_params.insert("limitPrice".to_string(), json!(limit_price));
+        let limit_price_value = Decimal::from_f32(limit_price).unwrap_or_default();
+        query_params.insert("limitPrice".to_string(), json!(limit_price_value));
 
         query_params.insert("side".to_string(), json!(side));
 
         query_params.insert("expiredType".to_string(), json!(expired_type));
 
         if let Some(rw) = base_amount {
-            query_params.insert("base_amount".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("baseAmount".to_string(), json!(rw));
         }
 
         if let Some(rw) = quote_amount {
-            query_params.insert("quote_amount".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("quoteAmount".to_string(), json!(rw));
         }
 
         if let Some(rw) = wallet_type {
-            query_params.insert("wallet_type".to_string(), json!(rw));
+            query_params.insert("walletType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::PlaceLimitOrderResponse>(
@@ -583,7 +581,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryLimitOpenOrdersResponse>(
@@ -622,23 +620,25 @@ impl TradeApi for TradeApiClient {
         query_params.insert("toAsset".to_string(), json!(to_asset));
 
         if let Some(rw) = from_amount {
-            query_params.insert("from_amount".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("fromAmount".to_string(), json!(rw));
         }
 
         if let Some(rw) = to_amount {
-            query_params.insert("to_amount".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("toAmount".to_string(), json!(rw));
         }
 
         if let Some(rw) = wallet_type {
-            query_params.insert("wallet_type".to_string(), json!(rw));
+            query_params.insert("walletType".to_string(), json!(rw));
         }
 
         if let Some(rw) = valid_time {
-            query_params.insert("valid_time".to_string(), json!(rw));
+            query_params.insert("validTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SendQuoteRequestResponse>(

--- a/src/copy_trading/rest_api/apis/future_copy_trading_api.rs
+++ b/src/copy_trading/rest_api/apis/future_copy_trading_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -69,9 +70,6 @@ pub struct GetFuturesLeadTraderStatusParams {
 impl GetFuturesLeadTraderStatusParams {
     /// Create a builder for [`get_futures_lead_trader_status`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetFuturesLeadTraderStatusParamsBuilder {
         GetFuturesLeadTraderStatusParamsBuilder::default()
@@ -95,9 +93,6 @@ pub struct GetFuturesLeadTradingSymbolWhitelistParams {
 impl GetFuturesLeadTradingSymbolWhitelistParams {
     /// Create a builder for [`get_futures_lead_trading_symbol_whitelist`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetFuturesLeadTradingSymbolWhitelistParamsBuilder {
         GetFuturesLeadTradingSymbolWhitelistParamsBuilder::default()
@@ -115,7 +110,7 @@ impl FutureCopyTradingApi for FutureCopyTradingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFuturesLeadTraderStatusResponse>(
@@ -142,7 +137,7 @@ impl FutureCopyTradingApi for FutureCopyTradingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFuturesLeadTradingSymbolWhitelistResponse>(

--- a/src/crypto_loan/rest_api/apis/flexible_rate_api.rs
+++ b/src/crypto_loan/rest_api/apis/flexible_rate_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -328,9 +329,6 @@ pub struct GetFlexibleLoanAssetsDataParams {
 impl GetFlexibleLoanAssetsDataParams {
     /// Create a builder for [`get_flexible_loan_assets_data`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetFlexibleLoanAssetsDataParamsBuilder {
         GetFlexibleLoanAssetsDataParamsBuilder::default()
@@ -388,9 +386,6 @@ pub struct GetFlexibleLoanBorrowHistoryParams {
 impl GetFlexibleLoanBorrowHistoryParams {
     /// Create a builder for [`get_flexible_loan_borrow_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetFlexibleLoanBorrowHistoryParamsBuilder {
         GetFlexibleLoanBorrowHistoryParamsBuilder::default()
@@ -419,9 +414,6 @@ pub struct GetFlexibleLoanCollateralAssetsDataParams {
 
 impl GetFlexibleLoanCollateralAssetsDataParams {
     /// Create a builder for [`get_flexible_loan_collateral_assets_data`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetFlexibleLoanCollateralAssetsDataParamsBuilder {
@@ -480,9 +472,6 @@ pub struct GetFlexibleLoanLiquidationHistoryParams {
 impl GetFlexibleLoanLiquidationHistoryParams {
     /// Create a builder for [`get_flexible_loan_liquidation_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetFlexibleLoanLiquidationHistoryParamsBuilder {
         GetFlexibleLoanLiquidationHistoryParamsBuilder::default()
@@ -540,9 +529,6 @@ pub struct GetFlexibleLoanLtvAdjustmentHistoryParams {
 impl GetFlexibleLoanLtvAdjustmentHistoryParams {
     /// Create a builder for [`get_flexible_loan_ltv_adjustment_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetFlexibleLoanLtvAdjustmentHistoryParamsBuilder {
         GetFlexibleLoanLtvAdjustmentHistoryParamsBuilder::default()
@@ -587,9 +573,6 @@ pub struct GetFlexibleLoanOngoingOrdersParams {
 
 impl GetFlexibleLoanOngoingOrdersParams {
     /// Create a builder for [`get_flexible_loan_ongoing_orders`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetFlexibleLoanOngoingOrdersParamsBuilder {
@@ -648,9 +631,6 @@ pub struct GetFlexibleLoanRepaymentHistoryParams {
 impl GetFlexibleLoanRepaymentHistoryParams {
     /// Create a builder for [`get_flexible_loan_repayment_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetFlexibleLoanRepaymentHistoryParamsBuilder {
         GetFlexibleLoanRepaymentHistoryParamsBuilder::default()
@@ -676,7 +656,7 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         query_params.insert("collateralCoin".to_string(), json!(collateral_coin));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CheckCollateralRepayRateResponse>(
@@ -712,12 +692,16 @@ impl FlexibleRateApi for FlexibleRateApiClient {
 
         query_params.insert("collateralCoin".to_string(), json!(collateral_coin));
 
-        query_params.insert("adjustmentAmount".to_string(), json!(adjustment_amount));
+        let adjustment_amount_value = Decimal::from_f32(adjustment_amount).unwrap_or_default();
+        query_params.insert(
+            "adjustmentAmount".to_string(),
+            json!(adjustment_amount_value),
+        );
 
         query_params.insert("direction".to_string(), json!(direction));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FlexibleLoanAdjustLtvResponse>(
@@ -752,7 +736,7 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         query_params.insert("collateralCoin".to_string(), json!(collateral_coin));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FlexibleLoanBorrowResponse>(
@@ -790,22 +774,23 @@ impl FlexibleRateApi for FlexibleRateApiClient {
 
         query_params.insert("collateralCoin".to_string(), json!(collateral_coin));
 
-        query_params.insert("repayAmount".to_string(), json!(repay_amount));
+        let repay_amount_value = Decimal::from_f32(repay_amount).unwrap_or_default();
+        query_params.insert("repayAmount".to_string(), json!(repay_amount_value));
 
         if let Some(rw) = collateral_return {
-            query_params.insert("collateral_return".to_string(), json!(rw));
+            query_params.insert("collateralReturn".to_string(), json!(rw));
         }
 
         if let Some(rw) = full_repayment {
-            query_params.insert("full_repayment".to_string(), json!(rw));
+            query_params.insert("fullRepayment".to_string(), json!(rw));
         }
 
         if let Some(rw) = repayment_type {
-            query_params.insert("repayment_type".to_string(), json!(rw));
+            query_params.insert("repaymentType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FlexibleLoanRepayResponse>(
@@ -835,11 +820,11 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleLoanAssetsDataResponse>(
@@ -874,19 +859,19 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -898,7 +883,7 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleLoanBorrowHistoryResponse>(
@@ -928,11 +913,11 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleLoanCollateralAssetsDataResponse>(
@@ -967,19 +952,19 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -991,7 +976,7 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleLoanLiquidationHistoryResponse>(
@@ -1026,19 +1011,19 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -1050,7 +1035,7 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleLoanLtvAdjustmentHistoryResponse>(
@@ -1083,11 +1068,11 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -1099,7 +1084,7 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleLoanOngoingOrdersResponse>(
@@ -1134,19 +1119,19 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -1158,7 +1143,7 @@ impl FlexibleRateApi for FlexibleRateApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleLoanRepaymentHistoryResponse>(

--- a/src/crypto_loan/rest_api/apis/stable_rate_api.rs
+++ b/src/crypto_loan/rest_api/apis/stable_rate_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -162,9 +163,6 @@ pub struct GetCryptoLoansIncomeHistoryParams {
 impl GetCryptoLoansIncomeHistoryParams {
     /// Create a builder for [`get_crypto_loans_income_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetCryptoLoansIncomeHistoryParamsBuilder {
         GetCryptoLoansIncomeHistoryParamsBuilder::default()
@@ -226,9 +224,6 @@ pub struct GetLoanBorrowHistoryParams {
 
 impl GetLoanBorrowHistoryParams {
     /// Create a builder for [`get_loan_borrow_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetLoanBorrowHistoryParamsBuilder {
@@ -292,9 +287,6 @@ pub struct GetLoanLtvAdjustmentHistoryParams {
 impl GetLoanLtvAdjustmentHistoryParams {
     /// Create a builder for [`get_loan_ltv_adjustment_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetLoanLtvAdjustmentHistoryParamsBuilder {
         GetLoanLtvAdjustmentHistoryParamsBuilder::default()
@@ -357,9 +349,6 @@ pub struct GetLoanRepaymentHistoryParams {
 impl GetLoanRepaymentHistoryParams {
     /// Create a builder for [`get_loan_repayment_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetLoanRepaymentHistoryParamsBuilder {
         GetLoanRepaymentHistoryParamsBuilder::default()
@@ -385,10 +374,11 @@ impl StableRateApi for StableRateApiClient {
 
         query_params.insert("collateralCoin".to_string(), json!(collateral_coin));
 
-        query_params.insert("repayAmount".to_string(), json!(repay_amount));
+        let repay_amount_value = Decimal::from_f32(repay_amount).unwrap_or_default();
+        query_params.insert("repayAmount".to_string(), json!(repay_amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CheckCollateralRepayRateStableRateResponse>(
@@ -427,15 +417,15 @@ impl StableRateApi for StableRateApiClient {
         }
 
         if let Some(rw) = r#type {
-            query_params.insert("r#type".to_string(), json!(rw));
+            query_params.insert("type".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -443,7 +433,7 @@ impl StableRateApi for StableRateApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetCryptoLoansIncomeHistoryResponseInner>>(
@@ -479,23 +469,23 @@ impl StableRateApi for StableRateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -507,7 +497,7 @@ impl StableRateApi for StableRateApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetLoanBorrowHistoryResponse>(
@@ -543,23 +533,23 @@ impl StableRateApi for StableRateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -571,7 +561,7 @@ impl StableRateApi for StableRateApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetLoanLtvAdjustmentHistoryResponse>(
@@ -607,23 +597,23 @@ impl StableRateApi for StableRateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -635,7 +625,7 @@ impl StableRateApi for StableRateApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetLoanRepaymentHistoryResponse>(

--- a/src/derivatives_trading_coin_futures/rest_api/apis/account_api.rs
+++ b/src/derivatives_trading_coin_futures/rest_api/apis/account_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -113,9 +114,6 @@ pub struct AccountInformationParams {
 impl AccountInformationParams {
     /// Create a builder for [`account_information`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AccountInformationParamsBuilder {
         AccountInformationParamsBuilder::default()
@@ -139,9 +137,6 @@ pub struct FuturesAccountBalanceParams {
 impl FuturesAccountBalanceParams {
     /// Create a builder for [`futures_account_balance`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> FuturesAccountBalanceParamsBuilder {
         FuturesAccountBalanceParamsBuilder::default()
@@ -164,9 +159,6 @@ pub struct GetCurrentPositionModeParams {
 
 impl GetCurrentPositionModeParams {
     /// Create a builder for [`get_current_position_mode`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetCurrentPositionModeParamsBuilder {
@@ -453,9 +445,6 @@ pub struct GetIncomeHistoryParams {
 impl GetIncomeHistoryParams {
     /// Create a builder for [`get_income_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetIncomeHistoryParamsBuilder {
         GetIncomeHistoryParamsBuilder::default()
@@ -485,9 +474,6 @@ pub struct NotionalBracketForPairParams {
 impl NotionalBracketForPairParams {
     /// Create a builder for [`notional_bracket_for_pair`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> NotionalBracketForPairParamsBuilder {
         NotionalBracketForPairParamsBuilder::default()
@@ -516,9 +502,6 @@ pub struct NotionalBracketForSymbolParams {
 
 impl NotionalBracketForSymbolParams {
     /// Create a builder for [`notional_bracket_for_symbol`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> NotionalBracketForSymbolParamsBuilder {
@@ -570,7 +553,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AccountInformationResponse>(
@@ -597,7 +580,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::FuturesAccountBalanceResponseInner>>(
@@ -624,7 +607,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetCurrentPositionModeResponse>(
@@ -659,7 +642,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDownloadIdForFuturesOrderHistoryResponse>(
@@ -694,7 +677,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDownloadIdForFuturesTradeHistoryResponse>(
@@ -730,7 +713,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDownloadIdForFuturesTransactionHistoryResponse>(
@@ -763,7 +746,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("downloadId".to_string(), json!(download_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFuturesOrderHistoryDownloadLinkByIdResponse>(
@@ -795,7 +778,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("downloadId".to_string(), json!(download_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFuturesTradeDownloadLinkByIdResponse>(
@@ -828,7 +811,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("downloadId".to_string(), json!(download_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFuturesTransactionHistoryDownloadLinkByIdResponse>(
@@ -867,15 +850,15 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = income_type {
-            query_params.insert("income_type".to_string(), json!(rw));
+            query_params.insert("incomeType".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -887,7 +870,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetIncomeHistoryResponseInner>>(
@@ -918,7 +901,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::NotionalBracketForPairResponseInner>>(
@@ -952,7 +935,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::NotionalBracketForSymbolResponseInner>>(
@@ -984,7 +967,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::UserCommissionRateResponse>(

--- a/src/derivatives_trading_coin_futures/rest_api/apis/market_data_api.rs
+++ b/src/derivatives_trading_coin_futures/rest_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -1061,9 +1062,6 @@ pub struct IndexPriceAndMarkPriceParams {
 impl IndexPriceAndMarkPriceParams {
     /// Create a builder for [`index_price_and_mark_price`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> IndexPriceAndMarkPriceParamsBuilder {
         IndexPriceAndMarkPriceParamsBuilder::default()
@@ -1584,9 +1582,6 @@ pub struct SymbolOrderBookTickerParams {
 impl SymbolOrderBookTickerParams {
     /// Create a builder for [`symbol_order_book_ticker`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SymbolOrderBookTickerParamsBuilder {
         SymbolOrderBookTickerParamsBuilder::default()
@@ -1615,9 +1610,6 @@ pub struct SymbolPriceTickerParams {
 
 impl SymbolPriceTickerParams {
     /// Create a builder for [`symbol_price_ticker`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> SymbolPriceTickerParamsBuilder {
@@ -1709,9 +1701,6 @@ pub struct Ticker24hrPriceChangeStatisticsParams {
 
 impl Ticker24hrPriceChangeStatisticsParams {
     /// Create a builder for [`ticker24hr_price_change_statistics`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> Ticker24hrPriceChangeStatisticsParamsBuilder {
@@ -1856,11 +1845,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::BasisResponseInner>>(
@@ -1916,15 +1905,15 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1970,11 +1959,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2034,11 +2023,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2132,11 +2121,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2179,11 +2168,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2228,11 +2217,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::LongShortRatioResponseInner>>(
@@ -2271,11 +2260,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2316,7 +2305,7 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::OldTradesLookupResponseInner>>(
@@ -2385,11 +2374,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::OpenInterestStatisticsResponseInner>>(
@@ -2456,11 +2445,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2624,11 +2613,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::TakerBuySellVolumeResponseInner>>(
@@ -2720,11 +2709,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::TopTraderLongShortRatioAccountsResponseInner>>(
@@ -2766,11 +2755,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::TopTraderLongShortRatioPositionsResponseInner>>(

--- a/src/derivatives_trading_coin_futures/rest_api/apis/portfolio_margin_endpoints_api.rs
+++ b/src/derivatives_trading_coin_futures/rest_api/apis/portfolio_margin_endpoints_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -95,7 +96,7 @@ impl PortfolioMarginEndpointsApi for PortfolioMarginEndpointsApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ClassicPortfolioMarginAccountInformationResponse>(

--- a/src/derivatives_trading_coin_futures/rest_api/apis/trade_api.rs
+++ b/src/derivatives_trading_coin_futures/rest_api/apis/trade_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -541,9 +542,6 @@ pub struct AccountTradeListParams {
 impl AccountTradeListParams {
     /// Create a builder for [`account_trade_list`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AccountTradeListParamsBuilder {
         AccountTradeListParamsBuilder::default()
@@ -601,9 +599,6 @@ pub struct AllOrdersParams {
 
 impl AllOrdersParams {
     /// Create a builder for [`all_orders`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AllOrdersParamsBuilder {
@@ -918,9 +913,6 @@ pub struct CurrentAllOpenOrdersParams {
 
 impl CurrentAllOpenOrdersParams {
     /// Create a builder for [`current_all_open_orders`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> CurrentAllOpenOrdersParamsBuilder {
@@ -1360,9 +1352,6 @@ pub struct PositionAdlQuantileEstimationParams {
 impl PositionAdlQuantileEstimationParams {
     /// Create a builder for [`position_adl_quantile_estimation`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> PositionAdlQuantileEstimationParamsBuilder {
         PositionAdlQuantileEstimationParamsBuilder::default()
@@ -1397,9 +1386,6 @@ pub struct PositionInformationParams {
 
 impl PositionInformationParams {
     /// Create a builder for [`position_information`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> PositionInformationParamsBuilder {
@@ -1542,9 +1528,6 @@ pub struct UsersForceOrdersParams {
 impl UsersForceOrdersParams {
     /// Create a builder for [`users_force_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> UsersForceOrdersParamsBuilder {
         UsersForceOrdersParamsBuilder::default()
@@ -1579,19 +1562,19 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1599,7 +1582,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AccountTradeListResponseInner>>(
@@ -1642,15 +1625,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1658,7 +1641,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AllOrdersResponseInner>>(
@@ -1693,7 +1676,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("countdownTime".to_string(), json!(countdown_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Value>(
@@ -1725,7 +1708,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelAllOpenOrdersResponse>(
@@ -1759,15 +1742,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id_list {
-            query_params.insert("order_id_list".to_string(), json!(rw));
+            query_params.insert("orderIdList".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id_list {
-            query_params.insert("orig_client_order_id_list".to_string(), json!(rw));
+            query_params.insert("origClientOrderIdList".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::CancelMultipleOrdersResponseInner>>(
@@ -1801,15 +1784,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelOrderResponse>(
@@ -1844,7 +1827,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("leverage".to_string(), json!(leverage));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeInitialLeverageResponse>(
@@ -1879,7 +1862,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("marginType".to_string(), json!(margin_type));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeMarginTypeResponse>(
@@ -1911,7 +1894,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("dualSidePosition".to_string(), json!(dual_side_position));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangePositionModeResponse>(
@@ -1950,7 +1933,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::CurrentAllOpenOrdersResponseInner>>(
@@ -1987,19 +1970,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2007,7 +1990,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetOrderModifyHistoryResponseInner>>(
@@ -2044,15 +2027,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = r#type {
-            query_params.insert("r#type".to_string(), json!(rw));
+            query_params.insert("type".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2060,7 +2043,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetPositionMarginChangeHistoryResponseInner>>(
@@ -2094,16 +2077,17 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("symbol".to_string(), json!(symbol));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ModifyIsolatedPositionMarginResponse>(
@@ -2135,7 +2119,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("batchOrders".to_string(), json!(batch_orders));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::ModifyMultipleOrdersResponseInner>>(
@@ -2175,27 +2159,29 @@ impl TradeApi for TradeApiClient {
         query_params.insert("side".to_string(), json!(side));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_match {
-            query_params.insert("price_match".to_string(), json!(rw));
+            query_params.insert("priceMatch".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ModifyOrderResponse>(
@@ -2248,67 +2234,72 @@ impl TradeApi for TradeApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = reduce_only {
-            query_params.insert("reduce_only".to_string(), json!(rw));
+            query_params.insert("reduceOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_price {
-            query_params.insert("stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = close_position {
-            query_params.insert("close_position".to_string(), json!(rw));
+            query_params.insert("closePosition".to_string(), json!(rw));
         }
 
         if let Some(rw) = activation_price {
-            query_params.insert("activation_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("activationPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = callback_rate {
-            query_params.insert("callback_rate".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("callbackRate".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_type {
-            query_params.insert("working_type".to_string(), json!(rw));
+            query_params.insert("workingType".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_protect {
-            query_params.insert("price_protect".to_string(), json!(rw));
+            query_params.insert("priceProtect".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_match {
-            query_params.insert("price_match".to_string(), json!(rw));
+            query_params.insert("priceMatch".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NewOrderResponse>(
@@ -2343,7 +2334,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::PositionAdlQuantileEstimationResponseInner>>(
@@ -2374,7 +2365,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = margin_asset {
-            query_params.insert("margin_asset".to_string(), json!(rw));
+            query_params.insert("marginAsset".to_string(), json!(rw));
         }
 
         if let Some(rw) = pair {
@@ -2382,7 +2373,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::PositionInformationResponseInner>>(
@@ -2416,15 +2407,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCurrentOpenOrderResponse>(
@@ -2458,15 +2449,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryOrderResponse>(
@@ -2504,15 +2495,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = auto_close_type {
-            query_params.insert("auto_close_type".to_string(), json!(rw));
+            query_params.insert("autoCloseType".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2520,7 +2511,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::UsersForceOrdersResponseInner>>(

--- a/src/derivatives_trading_coin_futures/rest_api/apis/user_data_streams_api.rs
+++ b/src/derivatives_trading_coin_futures/rest_api/apis/user_data_streams_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;

--- a/src/derivatives_trading_coin_futures/websocket_api/apis/account_api.rs
+++ b/src/derivatives_trading_coin_futures/websocket_api/apis/account_api.rs
@@ -15,6 +15,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -71,9 +72,6 @@ pub struct AccountInformationParams {
 impl AccountInformationParams {
     /// Create a builder for [`account_information`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AccountInformationParamsBuilder {
         AccountInformationParamsBuilder::default()
@@ -102,9 +100,6 @@ pub struct FuturesAccountBalanceParams {
 impl FuturesAccountBalanceParams {
     /// Create a builder for [`futures_account_balance`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> FuturesAccountBalanceParamsBuilder {
         FuturesAccountBalanceParamsBuilder::default()
@@ -124,7 +119,7 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -153,7 +148,7 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 

--- a/src/derivatives_trading_coin_futures/websocket_api/apis/trade_api.rs
+++ b/src/derivatives_trading_coin_futures/websocket_api/apis/trade_api.rs
@@ -15,6 +15,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -624,9 +625,6 @@ pub struct PositionInformationParams {
 impl PositionInformationParams {
     /// Create a builder for [`position_information`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> PositionInformationParamsBuilder {
         PositionInformationParamsBuilder::default()
@@ -698,18 +696,19 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = orig_client_order_id {
-            payload.insert("orig_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("origClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -743,24 +742,28 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert("side".to_string(), serde_json::json!(side));
-        payload.insert("quantity".to_string(), serde_json::json!(quantity));
-        payload.insert("price".to_string(), serde_json::json!(price));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        payload.insert("quantity".to_string(), serde_json::json!(quantity_value));
+        let price_value = Decimal::from_f32(price).unwrap_or_default();
+        payload.insert("price".to_string(), serde_json::json!(price_value));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = orig_client_order_id {
-            payload.insert("orig_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("origClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price_match {
-            payload.insert("price_match".to_string(), serde_json::json!(value));
+            payload.insert("priceMatch".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -805,62 +808,70 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert("side".to_string(), serde_json::json!(side));
-        payload.insert("r#type".to_string(), serde_json::json!(r#type));
+
+        payload.insert("type".to_string(), serde_json::json!(r#type));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = position_side {
-            payload.insert("position_side".to_string(), serde_json::json!(value));
+            payload.insert("positionSide".to_string(), serde_json::json!(value));
         }
         if let Some(value) = time_in_force {
-            payload.insert("time_in_force".to_string(), serde_json::json!(value));
+            payload.insert("timeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = quantity {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert("quantity".to_string(), serde_json::json!(value));
         }
         if let Some(value) = reduce_only {
-            payload.insert("reduce_only".to_string(), serde_json::json!(value));
+            payload.insert("reduceOnly".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert("price".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_client_order_id {
-            payload.insert("new_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("newClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_price {
-            payload.insert("stop_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("stopPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = close_position {
-            payload.insert("close_position".to_string(), serde_json::json!(value));
+            payload.insert("closePosition".to_string(), serde_json::json!(value));
         }
         if let Some(value) = activation_price {
-            payload.insert("activation_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("activationPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = callback_rate {
-            payload.insert("callback_rate".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("callbackRate".to_string(), serde_json::json!(value));
         }
         if let Some(value) = working_type {
-            payload.insert("working_type".to_string(), serde_json::json!(value));
+            payload.insert("workingType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price_protect {
-            payload.insert("price_protect".to_string(), serde_json::json!(value));
+            payload.insert("priceProtect".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_order_resp_type {
-            payload.insert("new_order_resp_type".to_string(), serde_json::json!(value));
+            payload.insert("newOrderRespType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price_match {
-            payload.insert("price_match".to_string(), serde_json::json!(value));
+            payload.insert("priceMatch".to_string(), serde_json::json!(value));
         }
         if let Some(value) = self_trade_prevention_mode {
             payload.insert(
-                "self_trade_prevention_mode".to_string(),
+                "selfTradePreventionMode".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -894,13 +905,13 @@ impl TradeApi for TradeApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = margin_asset {
-            payload.insert("margin_asset".to_string(), serde_json::json!(value));
+            payload.insert("marginAsset".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pair {
             payload.insert("pair".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -930,18 +941,19 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = orig_client_order_id {
-            payload.insert("orig_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("origClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 

--- a/src/derivatives_trading_coin_futures/websocket_api/apis/user_data_streams_api.rs
+++ b/src/derivatives_trading_coin_futures/websocket_api/apis/user_data_streams_api.rs
@@ -15,6 +15,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -69,9 +70,6 @@ pub struct CloseUserDataStreamParams {
 impl CloseUserDataStreamParams {
     /// Create a builder for [`close_user_data_stream`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> CloseUserDataStreamParamsBuilder {
         CloseUserDataStreamParamsBuilder::default()
@@ -94,9 +92,6 @@ pub struct KeepaliveUserDataStreamParams {
 impl KeepaliveUserDataStreamParams {
     /// Create a builder for [`keepalive_user_data_stream`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> KeepaliveUserDataStreamParamsBuilder {
         KeepaliveUserDataStreamParamsBuilder::default()
@@ -118,9 +113,6 @@ pub struct StartUserDataStreamParams {
 
 impl StartUserDataStreamParams {
     /// Create a builder for [`start_user_data_stream`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> StartUserDataStreamParamsBuilder {

--- a/src/derivatives_trading_coin_futures/websocket_streams/apis/websocket_market_streams_api.rs
+++ b/src/derivatives_trading_coin_futures/websocket_streams/apis/websocket_market_streams_api.rs
@@ -167,9 +167,6 @@ pub struct AllBookTickersStreamParams {
 impl AllBookTickersStreamParams {
     /// Create a builder for [`all_book_tickers_stream`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AllBookTickersStreamParamsBuilder {
         AllBookTickersStreamParamsBuilder::default()
@@ -191,9 +188,6 @@ pub struct AllMarketLiquidationOrderStreamsParams {
 
 impl AllMarketLiquidationOrderStreamsParams {
     /// Create a builder for [`all_market_liquidation_order_streams`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AllMarketLiquidationOrderStreamsParamsBuilder {
@@ -217,9 +211,6 @@ pub struct AllMarketMiniTickersStreamParams {
 impl AllMarketMiniTickersStreamParams {
     /// Create a builder for [`all_market_mini_tickers_stream`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AllMarketMiniTickersStreamParamsBuilder {
         AllMarketMiniTickersStreamParamsBuilder::default()
@@ -241,9 +232,6 @@ pub struct AllMarketTickersStreamsParams {
 
 impl AllMarketTickersStreamsParams {
     /// Create a builder for [`all_market_tickers_streams`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AllMarketTickersStreamsParamsBuilder {
@@ -316,9 +304,6 @@ pub struct ContractInfoStreamParams {
 
 impl ContractInfoStreamParams {
     /// Create a builder for [`contract_info_stream`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> ContractInfoStreamParamsBuilder {
@@ -914,7 +899,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
 
         let pairs: &[(&str, Option<String>)] = &[
             ("pair", Some(pair.clone())),
-            ("contract_type", Some(contract_type.clone())),
+            ("contractType", Some(contract_type.clone())),
             ("interval", Some(interval.clone())),
             ("id", id.clone()),
         ];
@@ -979,7 +964,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
         let pairs: &[(&str, Option<String>)] = &[
             ("symbol", Some(symbol.clone())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -1046,7 +1031,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
         let pairs: &[(&str, Option<String>)] = &[
             ("pair", Some(pair.clone())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -1267,7 +1252,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
         let pairs: &[(&str, Option<String>)] = &[
             ("pair", Some(pair.clone())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -1303,7 +1288,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
         let pairs: &[(&str, Option<String>)] = &[
             ("symbol", Some(symbol.clone())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -1339,7 +1324,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
             ("symbol", Some(symbol.clone())),
             ("levels", Some(levels.to_string())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -2089,7 +2074,7 @@ mod tests {
 
             let pairs: &[(&str, Option<String>)] = &[
                 ("pair", Some(pair.clone())),
-                ("contract_type", Some(contract_type.clone())),
+                ("contractType", Some(contract_type.clone())),
                 ("interval", Some(interval.clone())),
                 ("id", id.clone()),
             ];
@@ -2135,7 +2120,7 @@ mod tests {
                 ("pair",
                         Some(pair.clone())
                 ),
-                ("contract_type",
+                ("contractType",
                         Some(contract_type.clone())
                 ),
                 ("interval",
@@ -2191,7 +2176,7 @@ mod tests {
                 ("pair",
                         Some(pair.clone())
                 ),
-                ("contract_type",
+                ("contractType",
                         Some(contract_type.clone())
                 ),
                 ("interval",
@@ -2390,7 +2375,7 @@ mod tests {
             let pairs: &[(&str, Option<String>)] = &[
                 ("symbol", Some(symbol.clone())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -2433,7 +2418,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -2486,7 +2471,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -2699,7 +2684,7 @@ mod tests {
             let pairs: &[(&str, Option<String>)] = &[
                 ("pair", Some(pair.clone())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -2743,7 +2728,7 @@ mod tests {
             let pairs: &[(&str, Option<String>)] = &[
                 ("pair", Some(pair.clone())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -2802,7 +2787,7 @@ mod tests {
             let pairs: &[(&str, Option<String>)] = &[
                 ("pair", Some(pair.clone())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -3749,7 +3734,7 @@ mod tests {
             let pairs: &[(&str, Option<String>)] = &[
                 ("pair", Some(pair.clone())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -3792,7 +3777,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -3845,7 +3830,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -3904,7 +3889,7 @@ mod tests {
             let pairs: &[(&str, Option<String>)] = &[
                 ("symbol", Some(symbol.clone())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -3947,7 +3932,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -4000,7 +3985,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -4061,7 +4046,7 @@ mod tests {
                 ("symbol", Some(symbol.clone())),
                 ("levels", Some(levels.to_string())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -4109,7 +4094,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -4165,7 +4150,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];

--- a/src/derivatives_trading_options/rest_api/apis/account_api.rs
+++ b/src/derivatives_trading_options/rest_api/apis/account_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -206,9 +207,6 @@ pub struct OptionAccountInformationParams {
 impl OptionAccountInformationParams {
     /// Create a builder for [`option_account_information`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> OptionAccountInformationParamsBuilder {
         OptionAccountInformationParamsBuilder::default()
@@ -235,15 +233,15 @@ impl AccountApi for AccountApiClient {
         query_params.insert("currency".to_string(), json!(currency));
 
         if let Some(rw) = record_id {
-            query_params.insert("record_id".to_string(), json!(rw));
+            query_params.insert("recordId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -251,7 +249,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AccountFundingFlowResponseInner>>(
@@ -287,7 +285,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDownloadIdForOptionTransactionHistoryResponse>(
@@ -320,7 +318,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("downloadId".to_string(), json!(download_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetOptionTransactionHistoryDownloadLinkByIdResponse>(
@@ -347,7 +345,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::OptionAccountInformationResponse>(

--- a/src/derivatives_trading_options/rest_api/apis/market_data_api.rs
+++ b/src/derivatives_trading_options/rest_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -121,9 +122,6 @@ pub struct HistoricalExerciseRecordsParams {
 
 impl HistoricalExerciseRecordsParams {
     /// Create a builder for [`historical_exercise_records`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> HistoricalExerciseRecordsParamsBuilder {
@@ -266,9 +264,6 @@ pub struct OptionMarkPriceParams {
 impl OptionMarkPriceParams {
     /// Create a builder for [`option_mark_price`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> OptionMarkPriceParamsBuilder {
         OptionMarkPriceParamsBuilder::default()
@@ -326,9 +321,6 @@ pub struct RecentBlockTradesListParams {
 
 impl RecentBlockTradesListParams {
     /// Create a builder for [`recent_block_trades_list`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> RecentBlockTradesListParamsBuilder {
@@ -409,9 +401,6 @@ pub struct Ticker24hrPriceChangeStatisticsParams {
 impl Ticker24hrPriceChangeStatisticsParams {
     /// Create a builder for [`ticker24hr_price_change_statistics`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> Ticker24hrPriceChangeStatisticsParamsBuilder {
         Ticker24hrPriceChangeStatisticsParamsBuilder::default()
@@ -478,11 +467,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -523,11 +512,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -564,7 +553,7 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {

--- a/src/derivatives_trading_options/rest_api/apis/market_maker_block_trade_api.rs
+++ b/src/derivatives_trading_options/rest_api/apis/market_maker_block_trade_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -156,9 +157,6 @@ pub struct AccountBlockTradeListParams {
 
 impl AccountBlockTradeListParams {
     /// Create a builder for [`account_block_trade_list`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AccountBlockTradeListParamsBuilder {
@@ -380,9 +378,6 @@ pub struct QueryBlockTradeOrderParams {
 impl QueryBlockTradeOrderParams {
     /// Create a builder for [`query_block_trade_order`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryBlockTradeOrderParamsBuilder {
         QueryBlockTradeOrderParamsBuilder::default()
@@ -408,7 +403,7 @@ impl MarketMakerBlockTradeApi for MarketMakerBlockTradeApiClient {
         );
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AcceptBlockTradeOrderResponse>(
@@ -440,11 +435,11 @@ impl MarketMakerBlockTradeApi for MarketMakerBlockTradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = underlying {
@@ -452,7 +447,7 @@ impl MarketMakerBlockTradeApi for MarketMakerBlockTradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AccountBlockTradeListResponseInner>>(
@@ -487,7 +482,7 @@ impl MarketMakerBlockTradeApi for MarketMakerBlockTradeApiClient {
         );
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Value>(
@@ -522,7 +517,7 @@ impl MarketMakerBlockTradeApi for MarketMakerBlockTradeApiClient {
         );
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ExtendBlockTradeOrderResponse>(
@@ -564,12 +559,14 @@ impl MarketMakerBlockTradeApi for MarketMakerBlockTradeApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("price".to_string(), json!(price));
+        let price_value = Decimal::from_f32(price).unwrap_or_default();
+        query_params.insert("price".to_string(), json!(price_value));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NewBlockTradeOrderResponse>(
@@ -604,7 +601,7 @@ impl MarketMakerBlockTradeApi for MarketMakerBlockTradeApiClient {
         );
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryBlockTradeDetailsResponse>(
@@ -637,15 +634,15 @@ impl MarketMakerBlockTradeApi for MarketMakerBlockTradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = block_order_matching_key {
-            query_params.insert("block_order_matching_key".to_string(), json!(rw));
+            query_params.insert("blockOrderMatchingKey".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = underlying {
@@ -653,7 +650,7 @@ impl MarketMakerBlockTradeApi for MarketMakerBlockTradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryBlockTradeOrderResponseInner>>(

--- a/src/derivatives_trading_options/rest_api/apis/market_maker_endpoints_api.rs
+++ b/src/derivatives_trading_options/rest_api/apis/market_maker_endpoints_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -126,9 +127,6 @@ pub struct GetAutoCancelAllOpenOrdersParams {
 impl GetAutoCancelAllOpenOrdersParams {
     /// Create a builder for [`get_auto_cancel_all_open_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetAutoCancelAllOpenOrdersParamsBuilder {
         GetAutoCancelAllOpenOrdersParamsBuilder::default()
@@ -157,9 +155,6 @@ pub struct GetMarketMakerProtectionConfigParams {
 impl GetMarketMakerProtectionConfigParams {
     /// Create a builder for [`get_market_maker_protection_config`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetMarketMakerProtectionConfigParamsBuilder {
         GetMarketMakerProtectionConfigParamsBuilder::default()
@@ -182,9 +177,6 @@ pub struct OptionMarginAccountInformationParams {
 
 impl OptionMarginAccountInformationParams {
     /// Create a builder for [`option_margin_account_information`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> OptionMarginAccountInformationParamsBuilder {
@@ -213,9 +205,6 @@ pub struct ResetMarketMakerProtectionConfigParams {
 
 impl ResetMarketMakerProtectionConfigParams {
     /// Create a builder for [`reset_market_maker_protection_config`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> ResetMarketMakerProtectionConfigParamsBuilder {
@@ -308,9 +297,6 @@ pub struct SetMarketMakerProtectionConfigParams {
 impl SetMarketMakerProtectionConfigParams {
     /// Create a builder for [`set_market_maker_protection_config`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SetMarketMakerProtectionConfigParamsBuilder {
         SetMarketMakerProtectionConfigParamsBuilder::default()
@@ -333,7 +319,7 @@ impl MarketMakerEndpointsApi for MarketMakerEndpointsApiClient {
         query_params.insert("underlyings".to_string(), json!(underlyings));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AutoCancelAllOpenOrdersResponse>(
@@ -367,7 +353,7 @@ impl MarketMakerEndpointsApi for MarketMakerEndpointsApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetAutoCancelAllOpenOrdersResponse>(
@@ -401,7 +387,7 @@ impl MarketMakerEndpointsApi for MarketMakerEndpointsApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetMarketMakerProtectionConfigResponse>(
@@ -428,7 +414,7 @@ impl MarketMakerEndpointsApi for MarketMakerEndpointsApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::OptionMarginAccountInformationResponse>(
@@ -462,7 +448,7 @@ impl MarketMakerEndpointsApi for MarketMakerEndpointsApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ResetMarketMakerProtectionConfigResponse>(
@@ -497,7 +483,7 @@ impl MarketMakerEndpointsApi for MarketMakerEndpointsApiClient {
         query_params.insert("countdownTime".to_string(), json!(countdown_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SetAutoCancelAllOpenOrdersResponse>(
@@ -535,23 +521,25 @@ impl MarketMakerEndpointsApi for MarketMakerEndpointsApiClient {
         }
 
         if let Some(rw) = window_time_in_milliseconds {
-            query_params.insert("window_time_in_milliseconds".to_string(), json!(rw));
+            query_params.insert("windowTimeInMilliseconds".to_string(), json!(rw));
         }
 
         if let Some(rw) = frozen_time_in_milliseconds {
-            query_params.insert("frozen_time_in_milliseconds".to_string(), json!(rw));
+            query_params.insert("frozenTimeInMilliseconds".to_string(), json!(rw));
         }
 
         if let Some(rw) = qty_limit {
-            query_params.insert("qty_limit".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("qtyLimit".to_string(), json!(rw));
         }
 
         if let Some(rw) = delta_limit {
-            query_params.insert("delta_limit".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("deltaLimit".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SetMarketMakerProtectionConfigResponse>(

--- a/src/derivatives_trading_options/rest_api/apis/trade_api.rs
+++ b/src/derivatives_trading_options/rest_api/apis/trade_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -209,9 +210,6 @@ pub struct AccountTradeListParams {
 
 impl AccountTradeListParams {
     /// Create a builder for [`account_trade_list`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AccountTradeListParamsBuilder {
@@ -483,9 +481,6 @@ pub struct OptionPositionInformationParams {
 impl OptionPositionInformationParams {
     /// Create a builder for [`option_position_information`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> OptionPositionInformationParamsBuilder {
         OptionPositionInformationParamsBuilder::default()
@@ -567,9 +562,6 @@ pub struct QueryCurrentOpenOptionOrdersParams {
 
 impl QueryCurrentOpenOptionOrdersParams {
     /// Create a builder for [`query_current_open_option_orders`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryCurrentOpenOptionOrdersParamsBuilder {
@@ -708,9 +700,6 @@ pub struct UserExerciseRecordParams {
 impl UserExerciseRecordParams {
     /// Create a builder for [`user_exercise_record`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> UserExerciseRecordParamsBuilder {
         UserExerciseRecordParamsBuilder::default()
@@ -739,15 +728,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -755,7 +744,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AccountTradeListResponseInner>>(
@@ -787,7 +776,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("underlying".to_string(), json!(underlying));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelAllOptionOrdersByUnderlyingResponse>(
@@ -820,7 +809,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelAllOptionOrdersOnSpecificSymbolResponse>(
@@ -854,15 +843,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_ids {
-            query_params.insert("order_ids".to_string(), json!(rw));
+            query_params.insert("orderIds".to_string(), json!(rw));
         }
 
         if let Some(rw) = client_order_ids {
-            query_params.insert("client_order_ids".to_string(), json!(rw));
+            query_params.insert("clientOrderIds".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::CancelMultipleOptionOrdersResponseInner>>(
@@ -896,15 +885,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = client_order_id {
-            query_params.insert("client_order_id".to_string(), json!(rw));
+            query_params.insert("clientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelOptionOrderResponse>(
@@ -949,38 +938,40 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("type".to_string(), json!(r#type));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = reduce_only {
-            query_params.insert("reduce_only".to_string(), json!(rw));
+            query_params.insert("reduceOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = post_only {
-            query_params.insert("post_only".to_string(), json!(rw));
+            query_params.insert("postOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = client_order_id {
-            query_params.insert("client_order_id".to_string(), json!(rw));
+            query_params.insert("clientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = is_mmp {
-            query_params.insert("is_mmp".to_string(), json!(rw));
+            query_params.insert("isMmp".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NewOrderResponse>(
@@ -1014,7 +1005,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::OptionPositionInformationResponseInner>>(
@@ -1046,7 +1037,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("orders".to_string(), json!(orders));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::PlaceMultipleOrdersResponseInner>>(
@@ -1085,15 +1076,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1101,7 +1092,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryCurrentOpenOptionOrdersResponseInner>>(
@@ -1137,15 +1128,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1153,7 +1144,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryOptionOrderHistoryResponseInner>>(
@@ -1187,15 +1178,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = client_order_id {
-            query_params.insert("client_order_id".to_string(), json!(rw));
+            query_params.insert("clientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QuerySingleOrderResponse>(
@@ -1232,11 +1223,11 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1244,7 +1235,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::UserExerciseRecordResponseInner>>(

--- a/src/derivatives_trading_options/rest_api/apis/user_data_streams_api.rs
+++ b/src/derivatives_trading_options/rest_api/apis/user_data_streams_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;

--- a/src/derivatives_trading_options/websocket_streams/apis/websocket_market_streams_api.rs
+++ b/src/derivatives_trading_options/websocket_streams/apis/websocket_market_streams_api.rs
@@ -201,9 +201,6 @@ pub struct NewSymbolInfoParams {
 impl NewSymbolInfoParams {
     /// Create a builder for [`new_symbol_info`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> NewSymbolInfoParamsBuilder {
         NewSymbolInfoParamsBuilder::default()
@@ -470,7 +467,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
         } = params;
 
         let pairs: &[(&str, Option<String>)] = &[
-            ("underlying_asset", Some(underlying_asset.clone())),
+            ("underlyingAsset", Some(underlying_asset.clone())),
             ("id", id.clone()),
         ];
 
@@ -529,8 +526,8 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
         } = params;
 
         let pairs: &[(&str, Option<String>)] = &[
-            ("underlying_asset", Some(underlying_asset.clone())),
-            ("expiration_date", Some(expiration_date.clone())),
+            ("underlyingAsset", Some(underlying_asset.clone())),
+            ("expirationDate", Some(expiration_date.clone())),
             ("id", id.clone()),
         ];
 
@@ -571,7 +568,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
             ("symbol", Some(symbol.clone())),
             ("levels", Some(levels.to_string())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -637,8 +634,8 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
         } = params;
 
         let pairs: &[(&str, Option<String>)] = &[
-            ("underlying_asset", Some(underlying_asset.clone())),
-            ("expiration_date", Some(expiration_date.clone())),
+            ("underlyingAsset", Some(underlying_asset.clone())),
+            ("expirationDate", Some(expiration_date.clone())),
             ("id", id.clone()),
         ];
 
@@ -1035,7 +1032,7 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("underlying_asset", Some(underlying_asset.clone())),
+                ("underlyingAsset", Some(underlying_asset.clone())),
                 ("id", id.clone()),
             ];
 
@@ -1073,7 +1070,7 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("underlying_asset",
+                ("underlyingAsset",
                         Some(underlying_asset.clone())
                 ),
                 ("id",
@@ -1123,7 +1120,7 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("underlying_asset",
+                ("underlyingAsset",
                         Some(underlying_asset.clone())
                 ),
                 ("id",
@@ -1317,8 +1314,8 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("underlying_asset", Some(underlying_asset.clone())),
-                ("expiration_date", Some(expiration_date.clone())),
+                ("underlyingAsset", Some(underlying_asset.clone())),
+                ("expirationDate", Some(expiration_date.clone())),
                 ("id", id.clone()),
             ];
 
@@ -1358,10 +1355,10 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("underlying_asset",
+                ("underlyingAsset",
                         Some(underlying_asset.clone())
                 ),
-                ("expiration_date",
+                ("expirationDate",
                         Some(expiration_date.clone())
                 ),
                 ("id",
@@ -1411,10 +1408,10 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("underlying_asset",
+                ("underlyingAsset",
                         Some(underlying_asset.clone())
                 ),
-                ("expiration_date",
+                ("expirationDate",
                         Some(expiration_date.clone())
                 ),
                 ("id",
@@ -1478,7 +1475,7 @@ mod tests {
                 ("symbol", Some(symbol.clone())),
                 ("levels", Some(levels.to_string())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -1526,7 +1523,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -1582,7 +1579,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -1775,10 +1772,10 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("underlying_asset",
+                ("underlyingAsset",
                         Some(underlying_asset.clone())
                 ),
-                ("expiration_date",
+                ("expirationDate",
                         Some(expiration_date.clone())
                 ),
                 ("id",
@@ -1813,10 +1810,10 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("underlying_asset",
+                ("underlyingAsset",
                         Some(underlying_asset.clone())
                 ),
-                ("expiration_date",
+                ("expirationDate",
                         Some(expiration_date.clone())
                 ),
                 ("id",
@@ -1866,10 +1863,10 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("underlying_asset",
+                ("underlyingAsset",
                         Some(underlying_asset.clone())
                 ),
-                ("expiration_date",
+                ("expirationDate",
                         Some(expiration_date.clone())
                 ),
                 ("id",

--- a/src/derivatives_trading_portfolio_margin/rest_api/apis/account_api.rs
+++ b/src/derivatives_trading_portfolio_margin/rest_api/apis/account_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -241,9 +242,6 @@ pub struct AccountBalanceParams {
 impl AccountBalanceParams {
     /// Create a builder for [`account_balance`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AccountBalanceParamsBuilder {
         AccountBalanceParamsBuilder::default()
@@ -266,9 +264,6 @@ pub struct AccountInformationParams {
 
 impl AccountInformationParams {
     /// Create a builder for [`account_information`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AccountInformationParamsBuilder {
@@ -518,9 +513,6 @@ pub struct CmNotionalAndLeverageBracketsParams {
 impl CmNotionalAndLeverageBracketsParams {
     /// Create a builder for [`cm_notional_and_leverage_brackets`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> CmNotionalAndLeverageBracketsParamsBuilder {
         CmNotionalAndLeverageBracketsParamsBuilder::default()
@@ -543,9 +535,6 @@ pub struct FundAutoCollectionParams {
 
 impl FundAutoCollectionParams {
     /// Create a builder for [`fund_auto_collection`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> FundAutoCollectionParamsBuilder {
@@ -603,9 +592,6 @@ pub struct GetAutoRepayFuturesStatusParams {
 impl GetAutoRepayFuturesStatusParams {
     /// Create a builder for [`get_auto_repay_futures_status`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetAutoRepayFuturesStatusParamsBuilder {
         GetAutoRepayFuturesStatusParamsBuilder::default()
@@ -629,9 +615,6 @@ pub struct GetCmAccountDetailParams {
 impl GetCmAccountDetailParams {
     /// Create a builder for [`get_cm_account_detail`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetCmAccountDetailParamsBuilder {
         GetCmAccountDetailParamsBuilder::default()
@@ -654,9 +637,6 @@ pub struct GetCmCurrentPositionModeParams {
 
 impl GetCmCurrentPositionModeParams {
     /// Create a builder for [`get_cm_current_position_mode`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetCmCurrentPositionModeParamsBuilder {
@@ -712,9 +692,6 @@ pub struct GetCmIncomeHistoryParams {
 
 impl GetCmIncomeHistoryParams {
     /// Create a builder for [`get_cm_income_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetCmIncomeHistoryParamsBuilder {
@@ -905,9 +882,6 @@ pub struct GetMarginBorrowLoanInterestHistoryParams {
 impl GetMarginBorrowLoanInterestHistoryParams {
     /// Create a builder for [`get_margin_borrow_loan_interest_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetMarginBorrowLoanInterestHistoryParamsBuilder {
         GetMarginBorrowLoanInterestHistoryParamsBuilder::default()
@@ -930,9 +904,6 @@ pub struct GetUmAccountDetailParams {
 
 impl GetUmAccountDetailParams {
     /// Create a builder for [`get_um_account_detail`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetUmAccountDetailParamsBuilder {
@@ -957,9 +928,6 @@ pub struct GetUmAccountDetailV2Params {
 impl GetUmAccountDetailV2Params {
     /// Create a builder for [`get_um_account_detail_v2`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetUmAccountDetailV2ParamsBuilder {
         GetUmAccountDetailV2ParamsBuilder::default()
@@ -982,9 +950,6 @@ pub struct GetUmCurrentPositionModeParams {
 
 impl GetUmCurrentPositionModeParams {
     /// Create a builder for [`get_um_current_position_mode`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetUmCurrentPositionModeParamsBuilder {
@@ -1137,9 +1102,6 @@ pub struct GetUmIncomeHistoryParams {
 impl GetUmIncomeHistoryParams {
     /// Create a builder for [`get_um_income_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetUmIncomeHistoryParamsBuilder {
         GetUmIncomeHistoryParamsBuilder::default()
@@ -1268,9 +1230,6 @@ pub struct PortfolioMarginUmTradingQuantitativeRulesIndicatorsParams {
 impl PortfolioMarginUmTradingQuantitativeRulesIndicatorsParams {
     /// Create a builder for [`portfolio_margin_um_trading_quantitative_rules_indicators`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> PortfolioMarginUmTradingQuantitativeRulesIndicatorsParamsBuilder {
         PortfolioMarginUmTradingQuantitativeRulesIndicatorsParamsBuilder::default()
@@ -1305,9 +1264,6 @@ pub struct QueryCmPositionInformationParams {
 
 impl QueryCmPositionInformationParams {
     /// Create a builder for [`query_cm_position_information`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryCmPositionInformationParamsBuilder {
@@ -1512,9 +1468,6 @@ pub struct QueryPortfolioMarginNegativeBalanceInterestHistoryParams {
 impl QueryPortfolioMarginNegativeBalanceInterestHistoryParams {
     /// Create a builder for [`query_portfolio_margin_negative_balance_interest_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryPortfolioMarginNegativeBalanceInterestHistoryParamsBuilder {
         QueryPortfolioMarginNegativeBalanceInterestHistoryParamsBuilder::default()
@@ -1543,9 +1496,6 @@ pub struct QueryUmPositionInformationParams {
 
 impl QueryUmPositionInformationParams {
     /// Create a builder for [`query_um_position_information`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryUmPositionInformationParamsBuilder {
@@ -1615,9 +1565,6 @@ pub struct QueryUserRateLimitParams {
 impl QueryUserRateLimitParams {
     /// Create a builder for [`query_user_rate_limit`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryUserRateLimitParamsBuilder {
         QueryUserRateLimitParamsBuilder::default()
@@ -1641,9 +1588,6 @@ pub struct RepayFuturesNegativeBalanceParams {
 impl RepayFuturesNegativeBalanceParams {
     /// Create a builder for [`repay_futures_negative_balance`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> RepayFuturesNegativeBalanceParamsBuilder {
         RepayFuturesNegativeBalanceParamsBuilder::default()
@@ -1666,9 +1610,6 @@ pub struct UmFuturesAccountConfigurationParams {
 
 impl UmFuturesAccountConfigurationParams {
     /// Create a builder for [`um_futures_account_configuration`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> UmFuturesAccountConfigurationParamsBuilder {
@@ -1699,9 +1640,6 @@ pub struct UmFuturesSymbolConfigurationParams {
 impl UmFuturesSymbolConfigurationParams {
     /// Create a builder for [`um_futures_symbol_configuration`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> UmFuturesSymbolConfigurationParamsBuilder {
         UmFuturesSymbolConfigurationParamsBuilder::default()
@@ -1731,9 +1669,6 @@ pub struct UmNotionalAndLeverageBracketsParams {
 impl UmNotionalAndLeverageBracketsParams {
     /// Create a builder for [`um_notional_and_leverage_brackets`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> UmNotionalAndLeverageBracketsParamsBuilder {
         UmNotionalAndLeverageBracketsParamsBuilder::default()
@@ -1755,7 +1690,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AccountBalanceResponse>(
@@ -1782,7 +1717,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AccountInformationResponse>(
@@ -1812,12 +1747,13 @@ impl AccountApi for AccountApiClient {
 
         let mut query_params = BTreeMap::new();
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         query_params.insert("transferSide".to_string(), json!(transfer_side));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::BnbTransferResponse>(
@@ -1849,7 +1785,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("autoRepay".to_string(), json!(auto_repay));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeAutoRepayFuturesStatusResponse>(
@@ -1884,7 +1820,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("leverage".to_string(), json!(leverage));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeCmInitialLeverageResponse>(
@@ -1916,7 +1852,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("dualSidePosition".to_string(), json!(dual_side_position));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeCmPositionModeResponse>(
@@ -1951,7 +1887,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("leverage".to_string(), json!(leverage));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeUmInitialLeverageResponse>(
@@ -1983,7 +1919,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("dualSidePosition".to_string(), json!(dual_side_position));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeUmPositionModeResponse>(
@@ -2018,7 +1954,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::CmNotionalAndLeverageBracketsResponseInner>>(
@@ -2045,7 +1981,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FundAutoCollectionResponse>(
@@ -2074,7 +2010,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FundCollectionByAssetResponse>(
@@ -2101,7 +2037,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetAutoRepayFuturesStatusResponse>(
@@ -2128,7 +2064,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetCmAccountDetailResponse>(
@@ -2155,7 +2091,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetCmCurrentPositionModeResponse>(
@@ -2194,15 +2130,15 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = income_type {
-            query_params.insert("income_type".to_string(), json!(rw));
+            query_params.insert("incomeType".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -2214,7 +2150,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetCmIncomeHistoryResponseInner>>(
@@ -2250,7 +2186,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDownloadIdForUmFuturesOrderHistoryResponse>(
@@ -2286,7 +2222,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDownloadIdForUmFuturesTradeHistoryResponse>(
@@ -2322,7 +2258,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDownloadIdForUmFuturesTransactionHistoryResponse>(
@@ -2361,11 +2297,11 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -2381,7 +2317,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetMarginBorrowLoanInterestHistoryResponse>(
@@ -2408,7 +2344,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetUmAccountDetailResponse>(
@@ -2435,7 +2371,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetUmAccountDetailV2Response>(
@@ -2462,7 +2398,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetUmCurrentPositionModeResponse>(
@@ -2494,7 +2430,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("downloadId".to_string(), json!(download_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetUmFuturesOrderDownloadLinkByIdResponse>(
@@ -2526,7 +2462,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("downloadId".to_string(), json!(download_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetUmFuturesTradeDownloadLinkByIdResponse>(
@@ -2559,7 +2495,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("downloadId".to_string(), json!(download_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetUmFuturesTransactionDownloadLinkByIdResponse>(
@@ -2598,15 +2534,15 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = income_type {
-            query_params.insert("income_type".to_string(), json!(rw));
+            query_params.insert("incomeType".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -2618,7 +2554,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetUmIncomeHistoryResponseInner>>(
@@ -2650,7 +2586,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetUserCommissionRateForCmResponse>(
@@ -2682,7 +2618,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetUserCommissionRateForUmResponse>(
@@ -2711,7 +2647,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginMaxBorrowResponse>(
@@ -2747,7 +2683,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::PortfolioMarginUmTradingQuantitativeRulesIndicatorsResponse>(
@@ -2778,7 +2714,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = margin_asset {
-            query_params.insert("margin_asset".to_string(), json!(rw));
+            query_params.insert("marginAsset".to_string(), json!(rw));
         }
 
         if let Some(rw) = pair {
@@ -2786,7 +2722,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryCmPositionInformationResponseInner>>(
@@ -2824,15 +2760,15 @@ impl AccountApi for AccountApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = tx_id {
-            query_params.insert("tx_id".to_string(), json!(rw));
+            query_params.insert("txId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -2848,7 +2784,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryMarginLoanRecordResponse>(
@@ -2877,7 +2813,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryMarginMaxWithdrawResponse>(
@@ -2915,15 +2851,15 @@ impl AccountApi for AccountApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = tx_id {
-            query_params.insert("tx_id".to_string(), json!(rw));
+            query_params.insert("txId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -2939,7 +2875,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryMarginRepayRecordResponse>(
@@ -2980,11 +2916,11 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = size {
@@ -2992,7 +2928,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryPortfolioMarginNegativeBalanceInterestHistoryResponseInner>>(
@@ -3021,7 +2957,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryUmPositionInformationResponseInner>>(
@@ -3057,7 +2993,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryUserNegativeBalanceAutoExchangeRecordResponse>(
@@ -3084,7 +3020,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryUserRateLimitResponseInner>>(
@@ -3111,7 +3047,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::RepayFuturesNegativeBalanceResponse>(
@@ -3138,7 +3074,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::UmFuturesAccountConfigurationResponse>(
@@ -3173,7 +3109,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::UmFuturesSymbolConfigurationResponseInner>>(
@@ -3208,7 +3144,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::UmNotionalAndLeverageBracketsResponseInner>>(

--- a/src/derivatives_trading_portfolio_margin/rest_api/apis/market_data_api.rs
+++ b/src/derivatives_trading_portfolio_margin/rest_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;

--- a/src/derivatives_trading_portfolio_margin/rest_api/apis/trade_api.rs
+++ b/src/derivatives_trading_portfolio_margin/rest_api/apis/trade_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -1731,9 +1732,6 @@ pub struct CmAccountTradeListParams {
 impl CmAccountTradeListParams {
     /// Create a builder for [`cm_account_trade_list`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> CmAccountTradeListParamsBuilder {
         CmAccountTradeListParamsBuilder::default()
@@ -1763,9 +1761,6 @@ pub struct CmPositionAdlQuantileEstimationParams {
 impl CmPositionAdlQuantileEstimationParams {
     /// Create a builder for [`cm_position_adl_quantile_estimation`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> CmPositionAdlQuantileEstimationParamsBuilder {
         CmPositionAdlQuantileEstimationParamsBuilder::default()
@@ -1788,9 +1783,6 @@ pub struct GetUmFuturesBnbBurnStatusParams {
 
 impl GetUmFuturesBnbBurnStatusParams {
     /// Create a builder for [`get_um_futures_bnb_burn_status`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetUmFuturesBnbBurnStatusParamsBuilder {
@@ -2858,9 +2850,6 @@ pub struct QueryAllCmConditionalOrdersParams {
 impl QueryAllCmConditionalOrdersParams {
     /// Create a builder for [`query_all_cm_conditional_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryAllCmConditionalOrdersParamsBuilder {
         QueryAllCmConditionalOrdersParamsBuilder::default()
@@ -2950,9 +2939,6 @@ pub struct QueryAllCurrentCmOpenConditionalOrdersParams {
 impl QueryAllCurrentCmOpenConditionalOrdersParams {
     /// Create a builder for [`query_all_current_cm_open_conditional_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryAllCurrentCmOpenConditionalOrdersParamsBuilder {
         QueryAllCurrentCmOpenConditionalOrdersParamsBuilder::default()
@@ -2988,9 +2974,6 @@ pub struct QueryAllCurrentCmOpenOrdersParams {
 impl QueryAllCurrentCmOpenOrdersParams {
     /// Create a builder for [`query_all_current_cm_open_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryAllCurrentCmOpenOrdersParamsBuilder {
         QueryAllCurrentCmOpenOrdersParamsBuilder::default()
@@ -3020,9 +3003,6 @@ pub struct QueryAllCurrentUmOpenConditionalOrdersParams {
 impl QueryAllCurrentUmOpenConditionalOrdersParams {
     /// Create a builder for [`query_all_current_um_open_conditional_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryAllCurrentUmOpenConditionalOrdersParamsBuilder {
         QueryAllCurrentUmOpenConditionalOrdersParamsBuilder::default()
@@ -3051,9 +3031,6 @@ pub struct QueryAllCurrentUmOpenOrdersParams {
 
 impl QueryAllCurrentUmOpenOrdersParams {
     /// Create a builder for [`query_all_current_um_open_orders`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryAllCurrentUmOpenOrdersParamsBuilder {
@@ -3158,9 +3135,6 @@ pub struct QueryAllUmConditionalOrdersParams {
 
 impl QueryAllUmConditionalOrdersParams {
     /// Create a builder for [`query_all_um_conditional_orders`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryAllUmConditionalOrdersParamsBuilder {
@@ -3667,9 +3641,6 @@ pub struct QueryMarginAccountsAllOcoParams {
 impl QueryMarginAccountsAllOcoParams {
     /// Create a builder for [`query_margin_accounts_all_oco`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryMarginAccountsAllOcoParamsBuilder {
         QueryMarginAccountsAllOcoParamsBuilder::default()
@@ -3704,9 +3675,6 @@ pub struct QueryMarginAccountsOcoParams {
 impl QueryMarginAccountsOcoParams {
     /// Create a builder for [`query_margin_accounts_oco`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryMarginAccountsOcoParamsBuilder {
         QueryMarginAccountsOcoParamsBuilder::default()
@@ -3729,9 +3697,6 @@ pub struct QueryMarginAccountsOpenOcoParams {
 
 impl QueryMarginAccountsOpenOcoParams {
     /// Create a builder for [`query_margin_accounts_open_oco`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryMarginAccountsOpenOcoParamsBuilder {
@@ -3932,9 +3897,6 @@ pub struct QueryUsersCmForceOrdersParams {
 impl QueryUsersCmForceOrdersParams {
     /// Create a builder for [`query_users_cm_force_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryUsersCmForceOrdersParamsBuilder {
         QueryUsersCmForceOrdersParamsBuilder::default()
@@ -3977,9 +3939,6 @@ pub struct QueryUsersMarginForceOrdersParams {
 
 impl QueryUsersMarginForceOrdersParams {
     /// Create a builder for [`query_users_margin_force_orders`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryUsersMarginForceOrdersParamsBuilder {
@@ -4029,9 +3988,6 @@ pub struct QueryUsersUmForceOrdersParams {
 
 impl QueryUsersUmForceOrdersParams {
     /// Create a builder for [`query_users_um_force_orders`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryUsersUmForceOrdersParamsBuilder {
@@ -4147,9 +4103,6 @@ pub struct UmPositionAdlQuantileEstimationParams {
 impl UmPositionAdlQuantileEstimationParams {
     /// Create a builder for [`um_position_adl_quantile_estimation`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> UmPositionAdlQuantileEstimationParamsBuilder {
         UmPositionAdlQuantileEstimationParamsBuilder::default()
@@ -4172,7 +4125,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelAllCmOpenConditionalOrdersResponse>(
@@ -4204,7 +4157,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelAllCmOpenOrdersResponse>(
@@ -4236,7 +4189,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelAllUmOpenConditionalOrdersResponse>(
@@ -4268,7 +4221,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelAllUmOpenOrdersResponse>(
@@ -4302,15 +4255,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_strategy_id {
-            query_params.insert("new_client_strategy_id".to_string(), json!(rw));
+            query_params.insert("newClientStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelCmConditionalOrderResponse>(
@@ -4344,15 +4297,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelCmOrderResponse>(
@@ -4386,7 +4339,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::CancelMarginAccountAllOpenOrdersOnASymbolResponseInner>>(
@@ -4421,19 +4374,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_list_id {
-            query_params.insert("order_list_id".to_string(), json!(rw));
+            query_params.insert("orderListId".to_string(), json!(rw));
         }
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelMarginAccountOcoOrdersResponse>(
@@ -4468,19 +4421,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelMarginAccountOrderResponse>(
@@ -4514,15 +4467,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_strategy_id {
-            query_params.insert("new_client_strategy_id".to_string(), json!(rw));
+            query_params.insert("newClientStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelUmConditionalOrderResponse>(
@@ -4556,15 +4509,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelUmOrderResponse>(
@@ -4607,15 +4560,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -4623,7 +4576,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::CmAccountTradeListResponseInner>>(
@@ -4658,7 +4611,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::CmPositionAdlQuantileEstimationResponseInner>>(
@@ -4685,7 +4638,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetUmFuturesBnbBurnStatusResponse>(
@@ -4717,10 +4670,11 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountBorrowResponse>(
@@ -4766,50 +4720,56 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
-        query_params.insert("price".to_string(), json!(price));
+        let price_value = Decimal::from_f32(price).unwrap_or_default();
+        query_params.insert("price".to_string(), json!(price_value));
 
-        query_params.insert("stopPrice".to_string(), json!(stop_price));
+        let stop_price_value = Decimal::from_f32(stop_price).unwrap_or_default();
+        query_params.insert("stopPrice".to_string(), json!(stop_price_value));
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_client_order_id {
-            query_params.insert("limit_client_order_id".to_string(), json!(rw));
+            query_params.insert("limitClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_iceberg_qty {
-            query_params.insert("limit_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("limitIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_client_order_id {
-            query_params.insert("stop_client_order_id".to_string(), json!(rw));
+            query_params.insert("stopClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_limit_price {
-            query_params.insert("stop_limit_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopLimitPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_iceberg_qty {
-            query_params.insert("stop_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_limit_time_in_force {
-            query_params.insert("stop_limit_time_in_force".to_string(), json!(rw));
+            query_params.insert("stopLimitTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = side_effect_type {
-            query_params.insert("side_effect_type".to_string(), json!(rw));
+            query_params.insert("sideEffectType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountNewOcoResponse>(
@@ -4841,10 +4801,11 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountRepayResponse>(
@@ -4882,11 +4843,11 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = specify_repay_assets {
-            query_params.insert("specify_repay_assets".to_string(), json!(rw));
+            query_params.insert("specifyRepayAssets".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountRepayDebtResponse>(
@@ -4923,19 +4884,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -4943,7 +4904,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::MarginAccountTradeListResponseInner>>(
@@ -4982,24 +4943,26 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
-        query_params.insert("price".to_string(), json!(price));
+        let price_value = Decimal::from_f32(price).unwrap_or_default();
+        query_params.insert("price".to_string(), json!(price_value));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_match {
-            query_params.insert("price_match".to_string(), json!(rw));
+            query_params.insert("priceMatch".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ModifyCmOrderResponse>(
@@ -5038,24 +5001,26 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
-        query_params.insert("price".to_string(), json!(price));
+        let price_value = Decimal::from_f32(price).unwrap_or_default();
+        query_params.insert("price".to_string(), json!(price_value));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_match {
-            query_params.insert("price_match".to_string(), json!(rw));
+            query_params.insert("priceMatch".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ModifyUmOrderResponse>(
@@ -5104,51 +5069,56 @@ impl TradeApi for TradeApiClient {
         query_params.insert("strategyType".to_string(), json!(strategy_type));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = reduce_only {
-            query_params.insert("reduce_only".to_string(), json!(rw));
+            query_params.insert("reduceOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_type {
-            query_params.insert("working_type".to_string(), json!(rw));
+            query_params.insert("workingType".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_protect {
-            query_params.insert("price_protect".to_string(), json!(rw));
+            query_params.insert("priceProtect".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_strategy_id {
-            query_params.insert("new_client_strategy_id".to_string(), json!(rw));
+            query_params.insert("newClientStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_price {
-            query_params.insert("stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = activation_price {
-            query_params.insert("activation_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("activationPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = callback_rate {
-            query_params.insert("callback_rate".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("callbackRate".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NewCmConditionalOrderResponse>(
@@ -5194,39 +5164,41 @@ impl TradeApi for TradeApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = reduce_only {
-            query_params.insert("reduce_only".to_string(), json!(rw));
+            query_params.insert("reduceOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_match {
-            query_params.insert("price_match".to_string(), json!(rw));
+            query_params.insert("priceMatch".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NewCmOrderResponse>(
@@ -5275,51 +5247,56 @@ impl TradeApi for TradeApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = quote_order_qty {
-            query_params.insert("quote_order_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("quoteOrderQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_price {
-            query_params.insert("stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = iceberg_qty {
-            query_params.insert("iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("icebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = side_effect_type {
-            query_params.insert("side_effect_type".to_string(), json!(rw));
+            query_params.insert("sideEffectType".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = auto_repay_at_cancel {
-            query_params.insert("auto_repay_at_cancel".to_string(), json!(rw));
+            query_params.insert("autoRepayAtCancel".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NewMarginOrderResponse>(
@@ -5371,63 +5348,68 @@ impl TradeApi for TradeApiClient {
         query_params.insert("strategyType".to_string(), json!(strategy_type));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = reduce_only {
-            query_params.insert("reduce_only".to_string(), json!(rw));
+            query_params.insert("reduceOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_type {
-            query_params.insert("working_type".to_string(), json!(rw));
+            query_params.insert("workingType".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_protect {
-            query_params.insert("price_protect".to_string(), json!(rw));
+            query_params.insert("priceProtect".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_strategy_id {
-            query_params.insert("new_client_strategy_id".to_string(), json!(rw));
+            query_params.insert("newClientStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_price {
-            query_params.insert("stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = activation_price {
-            query_params.insert("activation_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("activationPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = callback_rate {
-            query_params.insert("callback_rate".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("callbackRate".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_match {
-            query_params.insert("price_match".to_string(), json!(rw));
+            query_params.insert("priceMatch".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = good_till_date {
-            query_params.insert("good_till_date".to_string(), json!(rw));
+            query_params.insert("goodTillDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NewUmConditionalOrderResponse>(
@@ -5475,47 +5457,49 @@ impl TradeApi for TradeApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = reduce_only {
-            query_params.insert("reduce_only".to_string(), json!(rw));
+            query_params.insert("reduceOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_match {
-            query_params.insert("price_match".to_string(), json!(rw));
+            query_params.insert("priceMatch".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = good_till_date {
-            query_params.insert("good_till_date".to_string(), json!(rw));
+            query_params.insert("goodTillDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NewUmOrderResponse>(
@@ -5554,15 +5538,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -5570,7 +5554,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryAllCmConditionalOrdersResponseInner>>(
@@ -5611,15 +5595,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -5627,7 +5611,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryAllCmOrdersResponseInner>>(
@@ -5663,7 +5647,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryAllCurrentCmOpenConditionalOrdersResponseInner>>(
@@ -5702,7 +5686,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryAllCmOrdersResponseInner>>(
@@ -5738,7 +5722,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryAllCurrentUmOpenConditionalOrdersResponseInner>>(
@@ -5773,7 +5757,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryAllCurrentUmOpenOrdersResponseInner>>(
@@ -5810,15 +5794,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -5826,7 +5810,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryAllMarginAccountOrdersResponseInner>>(
@@ -5865,15 +5849,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -5881,7 +5865,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryAllUmConditionalOrdersResponseInner>>(
@@ -5918,15 +5902,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -5934,7 +5918,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryAllCurrentUmOpenOrdersResponseInner>>(
@@ -5968,15 +5952,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_strategy_id {
-            query_params.insert("new_client_strategy_id".to_string(), json!(rw));
+            query_params.insert("newClientStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCmConditionalOrderHistoryResponse>(
@@ -6013,19 +5997,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -6033,7 +6017,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryCmModifyOrderHistoryResponseInner>>(
@@ -6067,15 +6051,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCmOrderResponse>(
@@ -6109,15 +6093,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_strategy_id {
-            query_params.insert("new_client_strategy_id".to_string(), json!(rw));
+            query_params.insert("newClientStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCurrentCmOpenConditionalOrderResponse>(
@@ -6151,15 +6135,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCurrentCmOpenOrderResponse>(
@@ -6192,7 +6176,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryCurrentMarginOpenOrderResponseInner>>(
@@ -6226,15 +6210,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_strategy_id {
-            query_params.insert("new_client_strategy_id".to_string(), json!(rw));
+            query_params.insert("newClientStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCurrentUmOpenConditionalOrderResponse>(
@@ -6268,15 +6252,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCurrentUmOpenOrderResponse>(
@@ -6310,15 +6294,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryMarginAccountOrderResponse>(
@@ -6351,15 +6335,15 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -6367,7 +6351,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryMarginAccountsAllOcoResponseInner>>(
@@ -6398,15 +6382,15 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = order_list_id {
-            query_params.insert("order_list_id".to_string(), json!(rw));
+            query_params.insert("orderListId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryMarginAccountsOcoResponse>(
@@ -6433,7 +6417,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryMarginAccountsOpenOcoResponseInner>>(
@@ -6467,15 +6451,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_strategy_id {
-            query_params.insert("new_client_strategy_id".to_string(), json!(rw));
+            query_params.insert("newClientStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryUmConditionalOrderHistoryResponse>(
@@ -6512,19 +6496,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -6532,7 +6516,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryUmModifyOrderHistoryResponseInner>>(
@@ -6566,15 +6550,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryUmOrderResponse>(
@@ -6612,15 +6596,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = auto_close_type {
-            query_params.insert("auto_close_type".to_string(), json!(rw));
+            query_params.insert("autoCloseType".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -6628,7 +6612,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryUsersCmForceOrdersResponseInner>>(
@@ -6661,11 +6645,11 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -6677,7 +6661,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryUsersMarginForceOrdersResponse>(
@@ -6715,15 +6699,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = auto_close_type {
-            query_params.insert("auto_close_type".to_string(), json!(rw));
+            query_params.insert("autoCloseType".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -6731,7 +6715,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryUsersUmForceOrdersResponseInner>>(
@@ -6763,7 +6747,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("feeBurn".to_string(), json!(fee_burn));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ToggleBnbBurnOnUmFuturesTradeResponse>(
@@ -6799,15 +6783,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -6815,7 +6799,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::UmAccountTradeListResponseInner>>(
@@ -6850,7 +6834,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::UmPositionAdlQuantileEstimationResponseInner>>(

--- a/src/derivatives_trading_portfolio_margin/rest_api/apis/user_data_streams_api.rs
+++ b/src/derivatives_trading_portfolio_margin/rest_api/apis/user_data_streams_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;

--- a/src/derivatives_trading_portfolio_margin_pro/rest_api/apis/account_api.rs
+++ b/src/derivatives_trading_portfolio_margin_pro/rest_api/apis/account_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -212,9 +213,6 @@ pub struct FundAutoCollectionParams {
 impl FundAutoCollectionParams {
     /// Create a builder for [`fund_auto_collection`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> FundAutoCollectionParamsBuilder {
         FundAutoCollectionParamsBuilder::default()
@@ -270,9 +268,6 @@ pub struct GetAutoRepayFuturesStatusParams {
 impl GetAutoRepayFuturesStatusParams {
     /// Create a builder for [`get_auto_repay_futures_status`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetAutoRepayFuturesStatusParamsBuilder {
         GetAutoRepayFuturesStatusParamsBuilder::default()
@@ -302,9 +297,6 @@ pub struct GetPortfolioMarginProAccountBalanceParams {
 impl GetPortfolioMarginProAccountBalanceParams {
     /// Create a builder for [`get_portfolio_margin_pro_account_balance`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetPortfolioMarginProAccountBalanceParamsBuilder {
         GetPortfolioMarginProAccountBalanceParamsBuilder::default()
@@ -328,9 +320,6 @@ pub struct GetPortfolioMarginProAccountInfoParams {
 impl GetPortfolioMarginProAccountInfoParams {
     /// Create a builder for [`get_portfolio_margin_pro_account_info`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetPortfolioMarginProAccountInfoParamsBuilder {
         GetPortfolioMarginProAccountInfoParamsBuilder::default()
@@ -353,9 +342,6 @@ pub struct GetPortfolioMarginProSpanAccountInfoParams {
 
 impl GetPortfolioMarginProSpanAccountInfoParams {
     /// Create a builder for [`get_portfolio_margin_pro_span_account_info`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetPortfolioMarginProSpanAccountInfoParamsBuilder {
@@ -480,9 +466,6 @@ pub struct PortfolioMarginProBankruptcyLoanRepayParams {
 impl PortfolioMarginProBankruptcyLoanRepayParams {
     /// Create a builder for [`portfolio_margin_pro_bankruptcy_loan_repay`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> PortfolioMarginProBankruptcyLoanRepayParamsBuilder {
         PortfolioMarginProBankruptcyLoanRepayParamsBuilder::default()
@@ -505,9 +488,6 @@ pub struct QueryPortfolioMarginProBankruptcyLoanAmountParams {
 
 impl QueryPortfolioMarginProBankruptcyLoanAmountParams {
     /// Create a builder for [`query_portfolio_margin_pro_bankruptcy_loan_amount`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryPortfolioMarginProBankruptcyLoanAmountParamsBuilder {
@@ -554,9 +534,6 @@ pub struct QueryPortfolioMarginProBankruptcyLoanRepayHistoryParams {
 impl QueryPortfolioMarginProBankruptcyLoanRepayHistoryParams {
     /// Create a builder for [`query_portfolio_margin_pro_bankruptcy_loan_repay_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryPortfolioMarginProBankruptcyLoanRepayHistoryParamsBuilder {
         QueryPortfolioMarginProBankruptcyLoanRepayHistoryParamsBuilder::default()
@@ -602,9 +579,6 @@ pub struct QueryPortfolioMarginProNegativeBalanceInterestHistoryParams {
 
 impl QueryPortfolioMarginProNegativeBalanceInterestHistoryParams {
     /// Create a builder for [`query_portfolio_margin_pro_negative_balance_interest_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryPortfolioMarginProNegativeBalanceInterestHistoryParamsBuilder {
@@ -686,9 +660,6 @@ pub struct RepayFuturesNegativeBalanceParams {
 impl RepayFuturesNegativeBalanceParams {
     /// Create a builder for [`repay_futures_negative_balance`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> RepayFuturesNegativeBalanceParamsBuilder {
         RepayFuturesNegativeBalanceParamsBuilder::default()
@@ -761,12 +732,13 @@ impl AccountApi for AccountApiClient {
 
         let mut query_params = BTreeMap::new();
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         query_params.insert("transferSide".to_string(), json!(transfer_side));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::BnbTransferResponse>(
@@ -798,7 +770,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("autoRepay".to_string(), json!(auto_repay));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeAutoRepayFuturesStatusResponse>(
@@ -825,7 +797,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FundAutoCollectionResponse>(
@@ -854,7 +826,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FundCollectionByAssetResponse>(
@@ -881,7 +853,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetAutoRepayFuturesStatusResponse>(
@@ -914,7 +886,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetPortfolioMarginProAccountBalanceResponseInner>>(
@@ -941,7 +913,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetPortfolioMarginProAccountInfoResponse>(
@@ -968,7 +940,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetPortfolioMarginProSpanAccountInfoResponse>(
@@ -1005,7 +977,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("transferType".to_string(), json!(transfer_type));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetTransferableEarnAssetBalanceForPortfolioMarginResponse>(
@@ -1040,10 +1012,11 @@ impl AccountApi for AccountApiClient {
 
         query_params.insert("targetAsset".to_string(), json!(target_asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MintBfusdForPortfolioMarginResponse>(
@@ -1075,7 +1048,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::PortfolioMarginProBankruptcyLoanRepayResponse>(
@@ -1103,7 +1076,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryPortfolioMarginProBankruptcyLoanAmountResponse>(
@@ -1138,11 +1111,11 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -1154,7 +1127,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryPortfolioMarginProBankruptcyLoanRepayHistoryResponse>(
@@ -1195,11 +1168,11 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = size {
@@ -1207,7 +1180,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<
@@ -1244,10 +1217,11 @@ impl AccountApi for AccountApiClient {
 
         query_params.insert("targetAsset".to_string(), json!(target_asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::RedeemBfusdForPortfolioMarginResponse>(
@@ -1278,7 +1252,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::RepayFuturesNegativeBalanceResponse>(
@@ -1313,10 +1287,11 @@ impl AccountApi for AccountApiClient {
 
         query_params.insert("transferType".to_string(), json!(transfer_type));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::TransferLdusdtForPortfolioMarginResponse>(

--- a/src/derivatives_trading_portfolio_margin_pro/rest_api/apis/market_data_api.rs
+++ b/src/derivatives_trading_portfolio_margin_pro/rest_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -79,9 +80,6 @@ pub struct PortfolioMarginProTieredCollateralRateParams {
 impl PortfolioMarginProTieredCollateralRateParams {
     /// Create a builder for [`portfolio_margin_pro_tiered_collateral_rate`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> PortfolioMarginProTieredCollateralRateParamsBuilder {
         PortfolioMarginProTieredCollateralRateParamsBuilder::default()
@@ -104,9 +102,6 @@ pub struct QueryPortfolioMarginAssetIndexPriceParams {
 
 impl QueryPortfolioMarginAssetIndexPriceParams {
     /// Create a builder for [`query_portfolio_margin_asset_index_price`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryPortfolioMarginAssetIndexPriceParamsBuilder {
@@ -169,7 +164,7 @@ impl MarketDataApi for MarketDataApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::PortfolioMarginProTieredCollateralRateResponseInner>>(

--- a/src/derivatives_trading_usds_futures/rest_api/apis/account_api.rs
+++ b/src/derivatives_trading_usds_futures/rest_api/apis/account_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -145,9 +146,6 @@ pub struct AccountInformationV2Params {
 impl AccountInformationV2Params {
     /// Create a builder for [`account_information_v2`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AccountInformationV2ParamsBuilder {
         AccountInformationV2ParamsBuilder::default()
@@ -170,9 +168,6 @@ pub struct AccountInformationV3Params {
 
 impl AccountInformationV3Params {
     /// Create a builder for [`account_information_v3`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AccountInformationV3ParamsBuilder {
@@ -197,9 +192,6 @@ pub struct FuturesAccountBalanceV2Params {
 impl FuturesAccountBalanceV2Params {
     /// Create a builder for [`futures_account_balance_v2`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> FuturesAccountBalanceV2ParamsBuilder {
         FuturesAccountBalanceV2ParamsBuilder::default()
@@ -223,9 +215,6 @@ pub struct FuturesAccountBalanceV3Params {
 impl FuturesAccountBalanceV3Params {
     /// Create a builder for [`futures_account_balance_v3`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> FuturesAccountBalanceV3ParamsBuilder {
         FuturesAccountBalanceV3ParamsBuilder::default()
@@ -248,9 +237,6 @@ pub struct FuturesAccountConfigurationParams {
 
 impl FuturesAccountConfigurationParams {
     /// Create a builder for [`futures_account_configuration`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> FuturesAccountConfigurationParamsBuilder {
@@ -281,9 +267,6 @@ pub struct FuturesTradingQuantitativeRulesIndicatorsParams {
 impl FuturesTradingQuantitativeRulesIndicatorsParams {
     /// Create a builder for [`futures_trading_quantitative_rules_indicators`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> FuturesTradingQuantitativeRulesIndicatorsParamsBuilder {
         FuturesTradingQuantitativeRulesIndicatorsParamsBuilder::default()
@@ -306,9 +289,6 @@ pub struct GetBnbBurnStatusParams {
 
 impl GetBnbBurnStatusParams {
     /// Create a builder for [`get_bnb_burn_status`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetBnbBurnStatusParamsBuilder {
@@ -333,9 +313,6 @@ pub struct GetCurrentMultiAssetsModeParams {
 impl GetCurrentMultiAssetsModeParams {
     /// Create a builder for [`get_current_multi_assets_mode`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetCurrentMultiAssetsModeParamsBuilder {
         GetCurrentMultiAssetsModeParamsBuilder::default()
@@ -358,9 +335,6 @@ pub struct GetCurrentPositionModeParams {
 
 impl GetCurrentPositionModeParams {
     /// Create a builder for [`get_current_position_mode`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetCurrentPositionModeParamsBuilder {
@@ -647,9 +621,6 @@ pub struct GetIncomeHistoryParams {
 impl GetIncomeHistoryParams {
     /// Create a builder for [`get_income_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetIncomeHistoryParamsBuilder {
         GetIncomeHistoryParamsBuilder::default()
@@ -679,9 +650,6 @@ pub struct NotionalAndLeverageBracketsParams {
 impl NotionalAndLeverageBracketsParams {
     /// Create a builder for [`notional_and_leverage_brackets`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> NotionalAndLeverageBracketsParamsBuilder {
         NotionalAndLeverageBracketsParamsBuilder::default()
@@ -704,9 +672,6 @@ pub struct QueryUserRateLimitParams {
 
 impl QueryUserRateLimitParams {
     /// Create a builder for [`query_user_rate_limit`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryUserRateLimitParamsBuilder {
@@ -736,9 +701,6 @@ pub struct SymbolConfigurationParams {
 
 impl SymbolConfigurationParams {
     /// Create a builder for [`symbol_configuration`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> SymbolConfigurationParamsBuilder {
@@ -822,7 +784,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AccountInformationV2Response>(
@@ -849,7 +811,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AccountInformationV3Response>(
@@ -876,7 +838,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::FuturesAccountBalanceV2ResponseInner>>(
@@ -903,7 +865,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::FuturesAccountBalanceV2ResponseInner>>(
@@ -930,7 +892,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FuturesAccountConfigurationResponse>(
@@ -965,7 +927,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FuturesTradingQuantitativeRulesIndicatorsResponse>(
@@ -992,7 +954,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetBnbBurnStatusResponse>(
@@ -1019,7 +981,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetCurrentMultiAssetsModeResponse>(
@@ -1046,7 +1008,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetCurrentPositionModeResponse>(
@@ -1081,7 +1043,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDownloadIdForFuturesOrderHistoryResponse>(
@@ -1116,7 +1078,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDownloadIdForFuturesTradeHistoryResponse>(
@@ -1152,7 +1114,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDownloadIdForFuturesTransactionHistoryResponse>(
@@ -1185,7 +1147,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("downloadId".to_string(), json!(download_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFuturesOrderHistoryDownloadLinkByIdResponse>(
@@ -1217,7 +1179,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("downloadId".to_string(), json!(download_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFuturesTradeDownloadLinkByIdResponse>(
@@ -1250,7 +1212,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("downloadId".to_string(), json!(download_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFuturesTransactionHistoryDownloadLinkByIdResponse>(
@@ -1289,15 +1251,15 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = income_type {
-            query_params.insert("income_type".to_string(), json!(rw));
+            query_params.insert("incomeType".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -1309,7 +1271,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetIncomeHistoryResponseInner>>(
@@ -1343,7 +1305,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NotionalAndLeverageBracketsResponse>(
@@ -1370,7 +1332,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryUserRateLimitResponseInner>>(
@@ -1404,7 +1366,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::SymbolConfigurationResponseInner>>(
@@ -1436,7 +1398,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("feeBurn".to_string(), json!(fee_burn));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ToggleBnbBurnOnFuturesTradeResponse>(
@@ -1468,7 +1430,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::UserCommissionRateResponse>(

--- a/src/derivatives_trading_usds_futures/rest_api/apis/convert_api.rs
+++ b/src/derivatives_trading_usds_futures/rest_api/apis/convert_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -114,9 +115,6 @@ pub struct ListAllConvertPairsParams {
 impl ListAllConvertPairsParams {
     /// Create a builder for [`list_all_convert_pairs`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> ListAllConvertPairsParamsBuilder {
         ListAllConvertPairsParamsBuilder::default()
@@ -143,9 +141,6 @@ pub struct OrderStatusParams {
 
 impl OrderStatusParams {
     /// Create a builder for [`order_status`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> OrderStatusParamsBuilder {
@@ -226,7 +221,7 @@ impl ConvertApi for ConvertApiClient {
         query_params.insert("quoteId".to_string(), json!(quote_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AcceptTheOfferedQuoteResponse>(
@@ -256,11 +251,11 @@ impl ConvertApi for ConvertApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = from_asset {
-            query_params.insert("from_asset".to_string(), json!(rw));
+            query_params.insert("fromAsset".to_string(), json!(rw));
         }
 
         if let Some(rw) = to_asset {
-            query_params.insert("to_asset".to_string(), json!(rw));
+            query_params.insert("toAsset".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::ListAllConvertPairsResponseInner>>(
@@ -287,11 +282,11 @@ impl ConvertApi for ConvertApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = quote_id {
-            query_params.insert("quote_id".to_string(), json!(rw));
+            query_params.insert("quoteId".to_string(), json!(rw));
         }
 
         send_request::<models::OrderStatusResponse>(
@@ -329,19 +324,21 @@ impl ConvertApi for ConvertApiClient {
         query_params.insert("toAsset".to_string(), json!(to_asset));
 
         if let Some(rw) = from_amount {
-            query_params.insert("from_amount".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("fromAmount".to_string(), json!(rw));
         }
 
         if let Some(rw) = to_amount {
-            query_params.insert("to_amount".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("toAmount".to_string(), json!(rw));
         }
 
         if let Some(rw) = valid_time {
-            query_params.insert("valid_time".to_string(), json!(rw));
+            query_params.insert("validTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SendQuoteRequestResponse>(

--- a/src/derivatives_trading_usds_futures/rest_api/apis/market_data_api.rs
+++ b/src/derivatives_trading_usds_futures/rest_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -848,9 +849,6 @@ pub struct CompositeIndexSymbolInformationParams {
 impl CompositeIndexSymbolInformationParams {
     /// Create a builder for [`composite_index_symbol_information`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> CompositeIndexSymbolInformationParamsBuilder {
         CompositeIndexSymbolInformationParamsBuilder::default()
@@ -1004,9 +1002,6 @@ pub struct GetFundingRateHistoryParams {
 
 impl GetFundingRateHistoryParams {
     /// Create a builder for [`get_funding_rate_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetFundingRateHistoryParamsBuilder {
@@ -1198,9 +1193,6 @@ pub struct MarkPriceParams {
 impl MarkPriceParams {
     /// Create a builder for [`mark_price`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> MarkPriceParamsBuilder {
         MarkPriceParamsBuilder::default()
@@ -1279,9 +1271,6 @@ pub struct MultiAssetsModeAssetIndexParams {
 
 impl MultiAssetsModeAssetIndexParams {
     /// Create a builder for [`multi_assets_mode_asset_index`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> MultiAssetsModeAssetIndexParamsBuilder {
@@ -1567,9 +1556,6 @@ pub struct QueryInsuranceFundBalanceSnapshotParams {
 impl QueryInsuranceFundBalanceSnapshotParams {
     /// Create a builder for [`query_insurance_fund_balance_snapshot`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryInsuranceFundBalanceSnapshotParamsBuilder {
         QueryInsuranceFundBalanceSnapshotParamsBuilder::default()
@@ -1625,9 +1611,6 @@ pub struct SymbolOrderBookTickerParams {
 impl SymbolOrderBookTickerParams {
     /// Create a builder for [`symbol_order_book_ticker`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SymbolOrderBookTickerParamsBuilder {
         SymbolOrderBookTickerParamsBuilder::default()
@@ -1651,9 +1634,6 @@ pub struct SymbolPriceTickerParams {
 impl SymbolPriceTickerParams {
     /// Create a builder for [`symbol_price_ticker`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SymbolPriceTickerParamsBuilder {
         SymbolPriceTickerParamsBuilder::default()
@@ -1676,9 +1656,6 @@ pub struct SymbolPriceTickerV2Params {
 
 impl SymbolPriceTickerV2Params {
     /// Create a builder for [`symbol_price_ticker_v2`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> SymbolPriceTickerV2ParamsBuilder {
@@ -1757,9 +1734,6 @@ pub struct Ticker24hrPriceChangeStatisticsParams {
 
 impl Ticker24hrPriceChangeStatisticsParams {
     /// Create a builder for [`ticker24hr_price_change_statistics`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> Ticker24hrPriceChangeStatisticsParamsBuilder {
@@ -1903,11 +1877,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("limit".to_string(), json!(limit));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::BasisResponseInner>>(
@@ -1991,15 +1965,15 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2045,11 +2019,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2109,11 +2083,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2176,11 +2150,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2222,11 +2196,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2271,11 +2245,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::LongShortRatioResponseInner>>(
@@ -2341,11 +2315,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2413,7 +2387,7 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::OldTradesLookupResponseInner>>(
@@ -2479,11 +2453,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::OpenInterestStatisticsResponseInner>>(
@@ -2550,11 +2524,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2787,11 +2761,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::TakerBuySellVolumeResponseInner>>(
@@ -2878,11 +2852,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::TopTraderLongShortRatioAccountsResponseInner>>(
@@ -2924,11 +2898,11 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::TopTraderLongShortRatioPositionsResponseInner>>(

--- a/src/derivatives_trading_usds_futures/rest_api/apis/portfolio_margin_endpoints_api.rs
+++ b/src/derivatives_trading_usds_futures/rest_api/apis/portfolio_margin_endpoints_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -95,7 +96,7 @@ impl PortfolioMarginEndpointsApi for PortfolioMarginEndpointsApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ClassicPortfolioMarginAccountInformationResponse>(

--- a/src/derivatives_trading_usds_futures/rest_api/apis/trade_api.rs
+++ b/src/derivatives_trading_usds_futures/rest_api/apis/trade_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -1052,9 +1053,6 @@ pub struct CurrentAllOpenOrdersParams {
 impl CurrentAllOpenOrdersParams {
     /// Create a builder for [`current_all_open_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> CurrentAllOpenOrdersParamsBuilder {
         CurrentAllOpenOrdersParamsBuilder::default()
@@ -1541,9 +1539,6 @@ pub struct PositionAdlQuantileEstimationParams {
 impl PositionAdlQuantileEstimationParams {
     /// Create a builder for [`position_adl_quantile_estimation`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> PositionAdlQuantileEstimationParamsBuilder {
         PositionAdlQuantileEstimationParamsBuilder::default()
@@ -1573,9 +1568,6 @@ pub struct PositionInformationV2Params {
 impl PositionInformationV2Params {
     /// Create a builder for [`position_information_v2`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> PositionInformationV2ParamsBuilder {
         PositionInformationV2ParamsBuilder::default()
@@ -1604,9 +1596,6 @@ pub struct PositionInformationV3Params {
 
 impl PositionInformationV3Params {
     /// Create a builder for [`position_information_v3`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> PositionInformationV3ParamsBuilder {
@@ -1884,9 +1873,6 @@ pub struct UsersForceOrdersParams {
 impl UsersForceOrdersParams {
     /// Create a builder for [`users_force_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> UsersForceOrdersParamsBuilder {
         UsersForceOrdersParamsBuilder::default()
@@ -1914,19 +1900,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1934,7 +1920,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AccountTradeListResponseInner>>(
@@ -1970,15 +1956,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1986,7 +1972,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AllOrdersResponseInner>>(
@@ -2021,7 +2007,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("countdownTime".to_string(), json!(countdown_time));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AutoCancelAllOpenOrdersResponse>(
@@ -2053,7 +2039,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelAllOpenOrdersResponse>(
@@ -2087,15 +2073,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id_list {
-            query_params.insert("order_id_list".to_string(), json!(rw));
+            query_params.insert("orderIdList".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id_list {
-            query_params.insert("orig_client_order_id_list".to_string(), json!(rw));
+            query_params.insert("origClientOrderIdList".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::CancelMultipleOrdersResponseInner>>(
@@ -2129,15 +2115,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelOrderResponse>(
@@ -2172,7 +2158,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("leverage".to_string(), json!(leverage));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeInitialLeverageResponse>(
@@ -2207,7 +2193,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("marginType".to_string(), json!(margin_type));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeMarginTypeResponse>(
@@ -2239,7 +2225,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("multiAssetsMargin".to_string(), json!(multi_assets_margin));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeMultiAssetsModeResponse>(
@@ -2271,7 +2257,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("dualSidePosition".to_string(), json!(dual_side_position));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangePositionModeResponse>(
@@ -2305,7 +2291,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AllOrdersResponseInner>>(
@@ -2342,19 +2328,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2362,7 +2348,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetOrderModifyHistoryResponseInner>>(
@@ -2399,15 +2385,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = r#type {
-            query_params.insert("r#type".to_string(), json!(rw));
+            query_params.insert("type".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2415,7 +2401,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetPositionMarginChangeHistoryResponseInner>>(
@@ -2449,16 +2435,17 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("symbol".to_string(), json!(symbol));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ModifyIsolatedPositionMarginResponse>(
@@ -2490,7 +2477,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("batchOrders".to_string(), json!(batch_orders));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::ModifyMultipleOrdersResponseInner>>(
@@ -2529,24 +2516,26 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
-        query_params.insert("price".to_string(), json!(price));
+        let price_value = Decimal::from_f32(price).unwrap_or_default();
+        query_params.insert("price".to_string(), json!(price_value));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_match {
-            query_params.insert("price_match".to_string(), json!(rw));
+            query_params.insert("priceMatch".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ModifyOrderResponse>(
@@ -2600,71 +2589,76 @@ impl TradeApi for TradeApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = reduce_only {
-            query_params.insert("reduce_only".to_string(), json!(rw));
+            query_params.insert("reduceOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_price {
-            query_params.insert("stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = close_position {
-            query_params.insert("close_position".to_string(), json!(rw));
+            query_params.insert("closePosition".to_string(), json!(rw));
         }
 
         if let Some(rw) = activation_price {
-            query_params.insert("activation_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("activationPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = callback_rate {
-            query_params.insert("callback_rate".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("callbackRate".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_type {
-            query_params.insert("working_type".to_string(), json!(rw));
+            query_params.insert("workingType".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_protect {
-            query_params.insert("price_protect".to_string(), json!(rw));
+            query_params.insert("priceProtect".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_match {
-            query_params.insert("price_match".to_string(), json!(rw));
+            query_params.insert("priceMatch".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = good_till_date {
-            query_params.insert("good_till_date".to_string(), json!(rw));
+            query_params.insert("goodTillDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NewOrderResponse>(
@@ -2696,7 +2690,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("batchOrders".to_string(), json!(batch_orders));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::PlaceMultipleOrdersResponseInner>>(
@@ -2731,7 +2725,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::PositionAdlQuantileEstimationResponseInner>>(
@@ -2765,7 +2759,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::PositionInformationV2ResponseInner>>(
@@ -2799,7 +2793,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::PositionInformationV3ResponseInner>>(
@@ -2833,15 +2827,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCurrentOpenOrderResponse>(
@@ -2875,15 +2869,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryOrderResponse>(
@@ -2937,71 +2931,76 @@ impl TradeApi for TradeApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = position_side {
-            query_params.insert("position_side".to_string(), json!(rw));
+            query_params.insert("positionSide".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = reduce_only {
-            query_params.insert("reduce_only".to_string(), json!(rw));
+            query_params.insert("reduceOnly".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_price {
-            query_params.insert("stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = close_position {
-            query_params.insert("close_position".to_string(), json!(rw));
+            query_params.insert("closePosition".to_string(), json!(rw));
         }
 
         if let Some(rw) = activation_price {
-            query_params.insert("activation_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("activationPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = callback_rate {
-            query_params.insert("callback_rate".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("callbackRate".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_type {
-            query_params.insert("working_type".to_string(), json!(rw));
+            query_params.insert("workingType".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_protect {
-            query_params.insert("price_protect".to_string(), json!(rw));
+            query_params.insert("priceProtect".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = price_match {
-            query_params.insert("price_match".to_string(), json!(rw));
+            query_params.insert("priceMatch".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = good_till_date {
-            query_params.insert("good_till_date".to_string(), json!(rw));
+            query_params.insert("goodTillDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::TestOrderResponse>(
@@ -3039,15 +3038,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = auto_close_type {
-            query_params.insert("auto_close_type".to_string(), json!(rw));
+            query_params.insert("autoCloseType".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -3055,7 +3054,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::UsersForceOrdersResponseInner>>(

--- a/src/derivatives_trading_usds_futures/rest_api/apis/user_data_streams_api.rs
+++ b/src/derivatives_trading_usds_futures/rest_api/apis/user_data_streams_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;

--- a/src/derivatives_trading_usds_futures/websocket_api/apis/account_api.rs
+++ b/src/derivatives_trading_usds_futures/websocket_api/apis/account_api.rs
@@ -15,6 +15,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -79,9 +80,6 @@ pub struct AccountInformationParams {
 impl AccountInformationParams {
     /// Create a builder for [`account_information`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AccountInformationParamsBuilder {
         AccountInformationParamsBuilder::default()
@@ -109,9 +107,6 @@ pub struct AccountInformationV2Params {
 
 impl AccountInformationV2Params {
     /// Create a builder for [`account_information_v2`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AccountInformationV2ParamsBuilder {
@@ -141,9 +136,6 @@ pub struct FuturesAccountBalanceParams {
 impl FuturesAccountBalanceParams {
     /// Create a builder for [`futures_account_balance`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> FuturesAccountBalanceParamsBuilder {
         FuturesAccountBalanceParamsBuilder::default()
@@ -172,9 +164,6 @@ pub struct FuturesAccountBalanceV2Params {
 impl FuturesAccountBalanceV2Params {
     /// Create a builder for [`futures_account_balance_v2`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> FuturesAccountBalanceV2ParamsBuilder {
         FuturesAccountBalanceV2ParamsBuilder::default()
@@ -194,7 +183,7 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -222,7 +211,7 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -251,7 +240,7 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -280,7 +269,7 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 

--- a/src/derivatives_trading_usds_futures/websocket_api/apis/market_data_api.rs
+++ b/src/derivatives_trading_usds_futures/websocket_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -112,9 +113,6 @@ pub struct SymbolOrderBookTickerParams {
 impl SymbolOrderBookTickerParams {
     /// Create a builder for [`symbol_order_book_ticker`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SymbolOrderBookTickerParamsBuilder {
         SymbolOrderBookTickerParamsBuilder::default()
@@ -143,9 +141,6 @@ pub struct SymbolPriceTickerParams {
 impl SymbolPriceTickerParams {
     /// Create a builder for [`symbol_price_ticker`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SymbolPriceTickerParamsBuilder {
         SymbolPriceTickerParamsBuilder::default()
@@ -161,6 +156,7 @@ impl MarketDataApi for MarketDataApiClient {
         let OrderBookParams { symbol, id, limit } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));

--- a/src/derivatives_trading_usds_futures/websocket_api/apis/trade_api.rs
+++ b/src/derivatives_trading_usds_futures/websocket_api/apis/trade_api.rs
@@ -15,6 +15,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -594,9 +595,6 @@ pub struct PositionInformationParams {
 impl PositionInformationParams {
     /// Create a builder for [`position_information`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> PositionInformationParamsBuilder {
         PositionInformationParamsBuilder::default()
@@ -630,9 +628,6 @@ pub struct PositionInformationV2Params {
 
 impl PositionInformationV2Params {
     /// Create a builder for [`position_information_v2`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> PositionInformationV2ParamsBuilder {
@@ -705,18 +700,19 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = orig_client_order_id {
-            payload.insert("orig_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("origClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -750,24 +746,28 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert("side".to_string(), serde_json::json!(side));
-        payload.insert("quantity".to_string(), serde_json::json!(quantity));
-        payload.insert("price".to_string(), serde_json::json!(price));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        payload.insert("quantity".to_string(), serde_json::json!(quantity_value));
+        let price_value = Decimal::from_f32(price).unwrap_or_default();
+        payload.insert("price".to_string(), serde_json::json!(price_value));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = orig_client_order_id {
-            payload.insert("orig_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("origClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price_match {
-            payload.insert("price_match".to_string(), serde_json::json!(value));
+            payload.insert("priceMatch".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -813,65 +813,73 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert("side".to_string(), serde_json::json!(side));
-        payload.insert("r#type".to_string(), serde_json::json!(r#type));
+
+        payload.insert("type".to_string(), serde_json::json!(r#type));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = position_side {
-            payload.insert("position_side".to_string(), serde_json::json!(value));
+            payload.insert("positionSide".to_string(), serde_json::json!(value));
         }
         if let Some(value) = time_in_force {
-            payload.insert("time_in_force".to_string(), serde_json::json!(value));
+            payload.insert("timeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = quantity {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert("quantity".to_string(), serde_json::json!(value));
         }
         if let Some(value) = reduce_only {
-            payload.insert("reduce_only".to_string(), serde_json::json!(value));
+            payload.insert("reduceOnly".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert("price".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_client_order_id {
-            payload.insert("new_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("newClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_price {
-            payload.insert("stop_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("stopPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = close_position {
-            payload.insert("close_position".to_string(), serde_json::json!(value));
+            payload.insert("closePosition".to_string(), serde_json::json!(value));
         }
         if let Some(value) = activation_price {
-            payload.insert("activation_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("activationPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = callback_rate {
-            payload.insert("callback_rate".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("callbackRate".to_string(), serde_json::json!(value));
         }
         if let Some(value) = working_type {
-            payload.insert("working_type".to_string(), serde_json::json!(value));
+            payload.insert("workingType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price_protect {
-            payload.insert("price_protect".to_string(), serde_json::json!(value));
+            payload.insert("priceProtect".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_order_resp_type {
-            payload.insert("new_order_resp_type".to_string(), serde_json::json!(value));
+            payload.insert("newOrderRespType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price_match {
-            payload.insert("price_match".to_string(), serde_json::json!(value));
+            payload.insert("priceMatch".to_string(), serde_json::json!(value));
         }
         if let Some(value) = self_trade_prevention_mode {
             payload.insert(
-                "self_trade_prevention_mode".to_string(),
+                "selfTradePreventionMode".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = good_till_date {
-            payload.insert("good_till_date".to_string(), serde_json::json!(value));
+            payload.insert("goodTillDate".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -907,7 +915,7 @@ impl TradeApi for TradeApiClient {
             payload.insert("symbol".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -943,7 +951,7 @@ impl TradeApi for TradeApiClient {
             payload.insert("symbol".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -973,18 +981,19 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = orig_client_order_id {
-            payload.insert("orig_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("origClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 

--- a/src/derivatives_trading_usds_futures/websocket_api/apis/user_data_streams_api.rs
+++ b/src/derivatives_trading_usds_futures/websocket_api/apis/user_data_streams_api.rs
@@ -15,6 +15,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -69,9 +70,6 @@ pub struct CloseUserDataStreamParams {
 impl CloseUserDataStreamParams {
     /// Create a builder for [`close_user_data_stream`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> CloseUserDataStreamParamsBuilder {
         CloseUserDataStreamParamsBuilder::default()
@@ -94,9 +92,6 @@ pub struct KeepaliveUserDataStreamParams {
 impl KeepaliveUserDataStreamParams {
     /// Create a builder for [`keepalive_user_data_stream`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> KeepaliveUserDataStreamParamsBuilder {
         KeepaliveUserDataStreamParamsBuilder::default()
@@ -118,9 +113,6 @@ pub struct StartUserDataStreamParams {
 
 impl StartUserDataStreamParams {
     /// Create a builder for [`start_user_data_stream`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> StartUserDataStreamParamsBuilder {

--- a/src/derivatives_trading_usds_futures/websocket_streams/apis/websocket_market_streams_api.rs
+++ b/src/derivatives_trading_usds_futures/websocket_streams/apis/websocket_market_streams_api.rs
@@ -163,9 +163,6 @@ pub struct AllBookTickersStreamParams {
 impl AllBookTickersStreamParams {
     /// Create a builder for [`all_book_tickers_stream`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AllBookTickersStreamParamsBuilder {
         AllBookTickersStreamParamsBuilder::default()
@@ -187,9 +184,6 @@ pub struct AllMarketLiquidationOrderStreamsParams {
 
 impl AllMarketLiquidationOrderStreamsParams {
     /// Create a builder for [`all_market_liquidation_order_streams`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AllMarketLiquidationOrderStreamsParamsBuilder {
@@ -213,9 +207,6 @@ pub struct AllMarketMiniTickersStreamParams {
 impl AllMarketMiniTickersStreamParams {
     /// Create a builder for [`all_market_mini_tickers_stream`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AllMarketMiniTickersStreamParamsBuilder {
         AllMarketMiniTickersStreamParamsBuilder::default()
@@ -237,9 +228,6 @@ pub struct AllMarketTickersStreamsParams {
 
 impl AllMarketTickersStreamsParams {
     /// Create a builder for [`all_market_tickers_streams`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AllMarketTickersStreamsParamsBuilder {
@@ -343,9 +331,6 @@ pub struct ContractInfoStreamParams {
 
 impl ContractInfoStreamParams {
     /// Create a builder for [`contract_info_stream`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> ContractInfoStreamParamsBuilder {
@@ -609,9 +594,6 @@ pub struct MarkPriceStreamForAllMarketParams {
 impl MarkPriceStreamForAllMarketParams {
     /// Create a builder for [`mark_price_stream_for_all_market`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> MarkPriceStreamForAllMarketParamsBuilder {
         MarkPriceStreamForAllMarketParamsBuilder::default()
@@ -633,9 +615,6 @@ pub struct MultiAssetsModeAssetIndexParams {
 
 impl MultiAssetsModeAssetIndexParams {
     /// Create a builder for [`multi_assets_mode_asset_index`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> MultiAssetsModeAssetIndexParamsBuilder {
@@ -872,7 +851,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
 
         let pairs: &[(&str, Option<String>)] = &[
             ("pair", Some(pair.clone())),
-            ("contract_type", Some(contract_type.clone())),
+            ("contractType", Some(contract_type.clone())),
             ("interval", Some(interval.clone())),
             ("id", id.clone()),
         ];
@@ -937,7 +916,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
         let pairs: &[(&str, Option<String>)] = &[
             ("symbol", Some(symbol.clone())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -1121,7 +1100,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
         let pairs: &[(&str, Option<String>)] = &[
             ("symbol", Some(symbol.clone())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -1150,7 +1129,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
         let MarkPriceStreamForAllMarketParams { id, update_speed } = params;
 
         let pairs: &[(&str, Option<String>)] =
-            &[("id", id.clone()), ("update_speed", update_speed.clone())];
+            &[("id", id.clone()), ("updateSpeed", update_speed.clone())];
 
         let vars: HashMap<_, _> = pairs
             .iter()
@@ -1214,7 +1193,7 @@ impl WebsocketMarketStreamsApi for WebsocketMarketStreamsApiClient {
             ("symbol", Some(symbol.clone())),
             ("levels", Some(levels.to_string())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -2108,7 +2087,7 @@ mod tests {
 
             let pairs: &[(&str, Option<String>)] = &[
                 ("pair", Some(pair.clone())),
-                ("contract_type", Some(contract_type.clone())),
+                ("contractType", Some(contract_type.clone())),
                 ("interval", Some(interval.clone())),
                 ("id", id.clone()),
             ];
@@ -2154,7 +2133,7 @@ mod tests {
                 ("pair",
                         Some(pair.clone())
                 ),
-                ("contract_type",
+                ("contractType",
                         Some(contract_type.clone())
                 ),
                 ("interval",
@@ -2210,7 +2189,7 @@ mod tests {
                 ("pair",
                         Some(pair.clone())
                 ),
-                ("contract_type",
+                ("contractType",
                         Some(contract_type.clone())
                 ),
                 ("interval",
@@ -2409,7 +2388,7 @@ mod tests {
             let pairs: &[(&str, Option<String>)] = &[
                 ("symbol", Some(symbol.clone())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -2452,7 +2431,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -2505,7 +2484,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -3284,7 +3263,7 @@ mod tests {
             let pairs: &[(&str, Option<String>)] = &[
                 ("symbol", Some(symbol.clone())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -3327,7 +3306,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -3380,7 +3359,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -3433,7 +3412,7 @@ mod tests {
             let MarkPriceStreamForAllMarketParams { id, update_speed } = params.clone();
 
             let pairs: &[(&str, Option<String>)] =
-                &[("id", id.clone()), ("update_speed", update_speed.clone())];
+                &[("id", id.clone()), ("updateSpeed", update_speed.clone())];
 
             let vars: HashMap<_, _> = pairs
                 .iter()
@@ -3472,7 +3451,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -3522,7 +3501,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -3717,7 +3696,7 @@ mod tests {
                 ("symbol", Some(symbol.clone())),
                 ("levels", Some(levels.to_string())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -3765,7 +3744,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -3821,7 +3800,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];

--- a/src/dual_investment/rest_api/apis/market_data_api.rs
+++ b/src/dual_investment/rest_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -132,15 +133,15 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("investCoin".to_string(), json!(invest_coin));
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = page_index {
-            query_params.insert("page_index".to_string(), json!(rw));
+            query_params.insert("pageIndex".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDualInvestmentProductListResponse>(

--- a/src/dual_investment/rest_api/apis/trade_api.rs
+++ b/src/dual_investment/rest_api/apis/trade_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -113,9 +114,6 @@ pub struct CheckDualInvestmentAccountsParams {
 impl CheckDualInvestmentAccountsParams {
     /// Create a builder for [`check_dual_investment_accounts`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> CheckDualInvestmentAccountsParamsBuilder {
         CheckDualInvestmentAccountsParamsBuilder::default()
@@ -152,9 +150,6 @@ pub struct GetDualInvestmentPositionsParams {
 
 impl GetDualInvestmentPositionsParams {
     /// Create a builder for [`get_dual_investment_positions`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetDualInvestmentPositionsParamsBuilder {
@@ -237,11 +232,11 @@ impl TradeApi for TradeApiClient {
         query_params.insert("positionId".to_string(), json!(position_id));
 
         if let Some(rw) = auto_compound_plan {
-            query_params.insert("auto_compound_plan".to_string(), json!(rw));
+            query_params.insert("AutoCompoundPlan".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ChangeAutoCompoundStatusResponse>(
@@ -268,7 +263,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CheckDualInvestmentAccountsResponse>(
@@ -304,15 +299,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = page_index {
-            query_params.insert("page_index".to_string(), json!(rw));
+            query_params.insert("pageIndex".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDualInvestmentPositionsResponse>(
@@ -348,12 +343,13 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("orderId".to_string(), json!(order_id));
 
-        query_params.insert("depositAmount".to_string(), json!(deposit_amount));
+        let deposit_amount_value = Decimal::from_f32(deposit_amount).unwrap_or_default();
+        query_params.insert("depositAmount".to_string(), json!(deposit_amount_value));
 
         query_params.insert("autoCompoundPlan".to_string(), json!(auto_compound_plan));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SubscribeDualInvestmentProductsResponse>(

--- a/src/fiat/rest_api/apis/fiat_api.rs
+++ b/src/fiat/rest_api/apis/fiat_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -180,11 +181,11 @@ impl FiatApi for FiatApiClient {
         query_params.insert("transactionType".to_string(), json!(transaction_type));
 
         if let Some(rw) = begin_time {
-            query_params.insert("begin_time".to_string(), json!(rw));
+            query_params.insert("beginTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -196,7 +197,7 @@ impl FiatApi for FiatApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFiatDepositWithdrawHistoryResponse>(
@@ -232,11 +233,11 @@ impl FiatApi for FiatApiClient {
         query_params.insert("transactionType".to_string(), json!(transaction_type));
 
         if let Some(rw) = begin_time {
-            query_params.insert("begin_time".to_string(), json!(rw));
+            query_params.insert("beginTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -248,7 +249,7 @@ impl FiatApi for FiatApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFiatPaymentsHistoryResponse>(

--- a/src/gift_card/rest_api/apis/market_data_api.rs
+++ b/src/gift_card/rest_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -176,9 +177,6 @@ pub struct FetchRsaPublicKeyParams {
 impl FetchRsaPublicKeyParams {
     /// Create a builder for [`fetch_rsa_public_key`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> FetchRsaPublicKeyParamsBuilder {
         FetchRsaPublicKeyParamsBuilder::default()
@@ -305,10 +303,14 @@ impl MarketDataApi for MarketDataApiClient {
 
         query_params.insert("faceToken".to_string(), json!(face_token));
 
-        query_params.insert("baseTokenAmount".to_string(), json!(base_token_amount));
+        let base_token_amount_value = Decimal::from_f32(base_token_amount).unwrap_or_default();
+        query_params.insert(
+            "baseTokenAmount".to_string(),
+            json!(base_token_amount_value),
+        );
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CreateADualTokenGiftCardResponse>(
@@ -340,10 +342,11 @@ impl MarketDataApi for MarketDataApiClient {
 
         query_params.insert("token".to_string(), json!(token));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CreateASingleTokenGiftCardResponse>(
@@ -370,7 +373,7 @@ impl MarketDataApi for MarketDataApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FetchRsaPublicKeyResponse>(
@@ -402,7 +405,7 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("baseToken".to_string(), json!(base_token));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FetchTokenLimitResponse>(
@@ -435,11 +438,11 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("code".to_string(), json!(code));
 
         if let Some(rw) = external_uid {
-            query_params.insert("external_uid".to_string(), json!(rw));
+            query_params.insert("externalUid".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::RedeemABinanceGiftCardResponse>(
@@ -472,7 +475,7 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("referenceNo".to_string(), json!(reference_no));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::VerifyBinanceGiftCardByGiftCardNumberResponse>(

--- a/src/margin_trading/rest_api/apis/account_api.rs
+++ b/src/margin_trading/rest_api/apis/account_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -196,9 +197,6 @@ pub struct GetBnbBurnStatusParams {
 impl GetBnbBurnStatusParams {
     /// Create a builder for [`get_bnb_burn_status`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetBnbBurnStatusParamsBuilder {
         GetBnbBurnStatusParamsBuilder::default()
@@ -220,9 +218,6 @@ pub struct GetSummaryOfMarginAccountParams {
 
 impl GetSummaryOfMarginAccountParams {
     /// Create a builder for [`get_summary_of_margin_account`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetSummaryOfMarginAccountParamsBuilder {
@@ -283,9 +278,6 @@ pub struct QueryCrossIsolatedMarginCapitalFlowParams {
 impl QueryCrossIsolatedMarginCapitalFlowParams {
     /// Create a builder for [`query_cross_isolated_margin_capital_flow`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryCrossIsolatedMarginCapitalFlowParamsBuilder {
         QueryCrossIsolatedMarginCapitalFlowParamsBuilder::default()
@@ -307,9 +299,6 @@ pub struct QueryCrossMarginAccountDetailsParams {
 
 impl QueryCrossMarginAccountDetailsParams {
     /// Create a builder for [`query_cross_margin_account_details`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryCrossMarginAccountDetailsParamsBuilder {
@@ -344,9 +333,6 @@ pub struct QueryCrossMarginFeeDataParams {
 impl QueryCrossMarginFeeDataParams {
     /// Create a builder for [`query_cross_margin_fee_data`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryCrossMarginFeeDataParamsBuilder {
         QueryCrossMarginFeeDataParamsBuilder::default()
@@ -368,9 +354,6 @@ pub struct QueryEnabledIsolatedMarginAccountLimitParams {
 
 impl QueryEnabledIsolatedMarginAccountLimitParams {
     /// Create a builder for [`query_enabled_isolated_margin_account_limit`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryEnabledIsolatedMarginAccountLimitParamsBuilder {
@@ -398,9 +381,6 @@ pub struct QueryIsolatedMarginAccountInfoParams {
 
 impl QueryIsolatedMarginAccountInfoParams {
     /// Create a builder for [`query_isolated_margin_account_info`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryIsolatedMarginAccountInfoParamsBuilder {
@@ -433,9 +413,6 @@ pub struct QueryIsolatedMarginFeeDataParams {
 
 impl QueryIsolatedMarginFeeDataParams {
     /// Create a builder for [`query_isolated_margin_fee_data`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryIsolatedMarginFeeDataParamsBuilder {
@@ -484,7 +461,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::DisableIsolatedMarginAccountResponse>(
@@ -516,7 +493,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::EnableIsolatedMarginAccountResponse>(
@@ -543,7 +520,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetBnbBurnStatusResponse>(
@@ -570,7 +547,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSummaryOfMarginAccountResponse>(
@@ -616,19 +593,19 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = r#type {
-            query_params.insert("r#type".to_string(), json!(rw));
+            query_params.insert("type".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -636,7 +613,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryCrossIsolatedMarginCapitalFlowResponseInner>>(
@@ -663,7 +640,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryCrossMarginAccountDetailsResponse>(
@@ -694,7 +671,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = vip_level {
-            query_params.insert("vip_level".to_string(), json!(rw));
+            query_params.insert("vipLevel".to_string(), json!(rw));
         }
 
         if let Some(rw) = coin {
@@ -702,7 +679,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryCrossMarginFeeDataResponseInner>>(
@@ -730,7 +707,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryEnabledIsolatedMarginAccountLimitResponse>(
@@ -764,7 +741,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryIsolatedMarginAccountInfoResponse>(
@@ -795,7 +772,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = vip_level {
-            query_params.insert("vip_level".to_string(), json!(rw));
+            query_params.insert("vipLevel".to_string(), json!(rw));
         }
 
         if let Some(rw) = symbol {
@@ -803,7 +780,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryIsolatedMarginFeeDataResponseInner>>(

--- a/src/margin_trading/rest_api/apis/borrow_repay_api.rs
+++ b/src/margin_trading/rest_api/apis/borrow_repay_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -149,9 +150,6 @@ pub struct GetInterestHistoryParams {
 
 impl GetInterestHistoryParams {
     /// Create a builder for [`get_interest_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetInterestHistoryParamsBuilder {
@@ -435,15 +433,15 @@ impl BorrowRepayApi for BorrowRepayApiClient {
         }
 
         if let Some(rw) = isolated_symbol {
-            query_params.insert("isolated_symbol".to_string(), json!(rw));
+            query_params.insert("isolatedSymbol".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -455,7 +453,7 @@ impl BorrowRepayApi for BorrowRepayApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetInterestHistoryResponse>(
@@ -499,7 +497,7 @@ impl BorrowRepayApi for BorrowRepayApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountBorrowRepayResponse>(
@@ -543,19 +541,19 @@ impl BorrowRepayApi for BorrowRepayApiClient {
         }
 
         if let Some(rw) = isolated_symbol {
-            query_params.insert("isolated_symbol".to_string(), json!(rw));
+            query_params.insert("isolatedSymbol".to_string(), json!(rw));
         }
 
         if let Some(rw) = tx_id {
-            query_params.insert("tx_id".to_string(), json!(rw));
+            query_params.insert("txId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -567,7 +565,7 @@ impl BorrowRepayApi for BorrowRepayApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryBorrowRepayRecordsInMarginAccountResponse>(
@@ -603,19 +601,19 @@ impl BorrowRepayApi for BorrowRepayApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = vip_level {
-            query_params.insert("vip_level".to_string(), json!(rw));
+            query_params.insert("vipLevel".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryMarginInterestRateHistoryResponseInner>>(
@@ -648,11 +646,11 @@ impl BorrowRepayApi for BorrowRepayApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = isolated_symbol {
-            query_params.insert("isolated_symbol".to_string(), json!(rw));
+            query_params.insert("isolatedSymbol".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryMaxBorrowResponse>(

--- a/src/margin_trading/rest_api/apis/market_data_api.rs
+++ b/src/margin_trading/rest_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -102,9 +103,6 @@ pub struct GetAllCrossMarginPairsParams {
 impl GetAllCrossMarginPairsParams {
     /// Create a builder for [`get_all_cross_margin_pairs`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetAllCrossMarginPairsParamsBuilder {
         GetAllCrossMarginPairsParamsBuilder::default()
@@ -132,9 +130,6 @@ pub struct GetAllIsolatedMarginSymbolParams {
 impl GetAllIsolatedMarginSymbolParams {
     /// Create a builder for [`get_all_isolated_margin_symbol`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetAllIsolatedMarginSymbolParamsBuilder {
         GetAllIsolatedMarginSymbolParamsBuilder::default()
@@ -158,9 +153,6 @@ pub struct GetAllMarginAssetsParams {
 impl GetAllMarginAssetsParams {
     /// Create a builder for [`get_all_margin_assets`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetAllMarginAssetsParamsBuilder {
         GetAllMarginAssetsParamsBuilder::default()
@@ -183,9 +175,6 @@ pub struct GetDelistScheduleParams {
 impl GetDelistScheduleParams {
     /// Create a builder for [`get_delist_schedule`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetDelistScheduleParamsBuilder {
         GetDelistScheduleParamsBuilder::default()
@@ -207,9 +196,6 @@ pub struct GetListScheduleParams {
 
 impl GetListScheduleParams {
     /// Create a builder for [`get_list_schedule`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetListScheduleParamsBuilder {
@@ -372,7 +358,7 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetAllIsolatedMarginSymbolResponseInner>>(
@@ -426,7 +412,7 @@ impl MarketDataApi for MarketDataApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetDelistScheduleResponseInner>>(
@@ -453,7 +439,7 @@ impl MarketDataApi for MarketDataApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetListScheduleResponseInner>>(
@@ -491,7 +477,7 @@ impl MarketDataApi for MarketDataApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryIsolatedMarginTierDataResponseInner>>(

--- a/src/margin_trading/rest_api/apis/risk_data_stream_api.rs
+++ b/src/margin_trading/rest_api/apis/risk_data_stream_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;

--- a/src/margin_trading/rest_api/apis/trade_api.rs
+++ b/src/margin_trading/rest_api/apis/trade_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -373,9 +374,6 @@ pub struct DeleteSpecialKeyParams {
 impl DeleteSpecialKeyParams {
     /// Create a builder for [`delete_special_key`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> DeleteSpecialKeyParamsBuilder {
         DeleteSpecialKeyParamsBuilder::default()
@@ -460,9 +458,6 @@ pub struct GetForceLiquidationRecordParams {
 impl GetForceLiquidationRecordParams {
     /// Create a builder for [`get_force_liquidation_record`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetForceLiquidationRecordParamsBuilder {
         GetForceLiquidationRecordParamsBuilder::default()
@@ -484,9 +479,6 @@ pub struct GetSmallLiabilityExchangeCoinListParams {
 
 impl GetSmallLiabilityExchangeCoinListParams {
     /// Create a builder for [`get_small_liability_exchange_coin_list`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetSmallLiabilityExchangeCoinListParamsBuilder {
@@ -1374,9 +1366,6 @@ pub struct QueryCurrentMarginOrderCountUsageParams {
 impl QueryCurrentMarginOrderCountUsageParams {
     /// Create a builder for [`query_current_margin_order_count_usage`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryCurrentMarginOrderCountUsageParamsBuilder {
         QueryCurrentMarginOrderCountUsageParamsBuilder::default()
@@ -1429,9 +1418,6 @@ pub struct QueryMarginAccountsAllOcoParams {
 
 impl QueryMarginAccountsAllOcoParams {
     /// Create a builder for [`query_margin_accounts_all_oco`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryMarginAccountsAllOcoParamsBuilder {
@@ -1535,9 +1521,6 @@ pub struct QueryMarginAccountsOcoParams {
 impl QueryMarginAccountsOcoParams {
     /// Create a builder for [`query_margin_accounts_oco`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryMarginAccountsOcoParamsBuilder {
         QueryMarginAccountsOcoParamsBuilder::default()
@@ -1570,9 +1553,6 @@ pub struct QueryMarginAccountsOpenOcoParams {
 impl QueryMarginAccountsOpenOcoParams {
     /// Create a builder for [`query_margin_accounts_open_oco`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryMarginAccountsOpenOcoParamsBuilder {
         QueryMarginAccountsOpenOcoParamsBuilder::default()
@@ -1604,9 +1584,6 @@ pub struct QueryMarginAccountsOpenOrdersParams {
 
 impl QueryMarginAccountsOpenOrdersParams {
     /// Create a builder for [`query_margin_accounts_open_orders`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryMarginAccountsOpenOrdersParamsBuilder {
@@ -1748,9 +1725,6 @@ pub struct QuerySpecialKeyParams {
 impl QuerySpecialKeyParams {
     /// Create a builder for [`query_special_key`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QuerySpecialKeyParamsBuilder {
         QuerySpecialKeyParamsBuilder::default()
@@ -1777,9 +1751,6 @@ pub struct QuerySpecialKeyListParams {
 
 impl QuerySpecialKeyListParams {
     /// Create a builder for [`query_special_key_list`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QuerySpecialKeyListParamsBuilder {
@@ -1846,15 +1817,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = public_key {
-            query_params.insert("public_key".to_string(), json!(rw));
+            query_params.insert("publicKey".to_string(), json!(rw));
         }
 
         if let Some(rw) = permission_mode {
-            query_params.insert("permission_mode".to_string(), json!(rw));
+            query_params.insert("permissionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CreateSpecialKeyResponse>(
@@ -1885,7 +1856,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = api_name {
-            query_params.insert("api_name".to_string(), json!(rw));
+            query_params.insert("apiName".to_string(), json!(rw));
         }
 
         if let Some(rw) = symbol {
@@ -1893,7 +1864,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Value>(
@@ -1930,7 +1901,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Value>(
@@ -1964,15 +1935,15 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = isolated_symbol {
-            query_params.insert("isolated_symbol".to_string(), json!(rw));
+            query_params.insert("isolatedSymbol".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -1984,7 +1955,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetForceLiquidationRecordResponse>(
@@ -2012,7 +1983,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetSmallLiabilityExchangeCoinListResponseInner>>(
@@ -2049,15 +2020,15 @@ impl TradeApi for TradeApiClient {
         query_params.insert("size".to_string(), json!(size));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSmallLiabilityExchangeHistoryResponse>(
@@ -2092,11 +2063,11 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::MarginAccountCancelAllOpenOrdersOnASymbolResponseInner>>(
@@ -2132,23 +2103,23 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = order_list_id {
-            query_params.insert("order_list_id".to_string(), json!(rw));
+            query_params.insert("orderListId".to_string(), json!(rw));
         }
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountCancelOcoResponse>(
@@ -2184,23 +2155,23 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountCancelOrderResponse>(
@@ -2249,62 +2220,68 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
-        query_params.insert("price".to_string(), json!(price));
+        let price_value = Decimal::from_f32(price).unwrap_or_default();
+        query_params.insert("price".to_string(), json!(price_value));
 
-        query_params.insert("stopPrice".to_string(), json!(stop_price));
+        let stop_price_value = Decimal::from_f32(stop_price).unwrap_or_default();
+        query_params.insert("stopPrice".to_string(), json!(stop_price_value));
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_client_order_id {
-            query_params.insert("limit_client_order_id".to_string(), json!(rw));
+            query_params.insert("limitClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_iceberg_qty {
-            query_params.insert("limit_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("limitIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_client_order_id {
-            query_params.insert("stop_client_order_id".to_string(), json!(rw));
+            query_params.insert("stopClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_limit_price {
-            query_params.insert("stop_limit_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopLimitPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_iceberg_qty {
-            query_params.insert("stop_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_limit_time_in_force {
-            query_params.insert("stop_limit_time_in_force".to_string(), json!(rw));
+            query_params.insert("stopLimitTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = side_effect_type {
-            query_params.insert("side_effect_type".to_string(), json!(rw));
+            query_params.insert("sideEffectType".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = auto_repay_at_cancel {
-            query_params.insert("auto_repay_at_cancel".to_string(), json!(rw));
+            query_params.insert("autoRepayAtCancel".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountNewOcoResponse>(
@@ -2354,55 +2331,60 @@ impl TradeApi for TradeApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = quote_order_qty {
-            query_params.insert("quote_order_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("quoteOrderQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_price {
-            query_params.insert("stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = iceberg_qty {
-            query_params.insert("iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("icebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = side_effect_type {
-            query_params.insert("side_effect_type".to_string(), json!(rw));
+            query_params.insert("sideEffectType".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = auto_repay_at_cancel {
-            query_params.insert("auto_repay_at_cancel".to_string(), json!(rw));
+            query_params.insert("autoRepayAtCancel".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountNewOrderResponse>(
@@ -2458,72 +2440,83 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("workingSide".to_string(), json!(working_side));
 
-        query_params.insert("workingPrice".to_string(), json!(working_price));
+        let working_price_value = Decimal::from_f32(working_price).unwrap_or_default();
+        query_params.insert("workingPrice".to_string(), json!(working_price_value));
 
-        query_params.insert("workingQuantity".to_string(), json!(working_quantity));
+        let working_quantity_value = Decimal::from_f32(working_quantity).unwrap_or_default();
+        query_params.insert("workingQuantity".to_string(), json!(working_quantity_value));
 
-        query_params.insert("workingIcebergQty".to_string(), json!(working_iceberg_qty));
+        let working_iceberg_qty_value = Decimal::from_f32(working_iceberg_qty).unwrap_or_default();
+        query_params.insert(
+            "workingIcebergQty".to_string(),
+            json!(working_iceberg_qty_value),
+        );
 
         query_params.insert("pendingType".to_string(), json!(pending_type));
 
         query_params.insert("pendingSide".to_string(), json!(pending_side));
 
-        query_params.insert("pendingQuantity".to_string(), json!(pending_quantity));
+        let pending_quantity_value = Decimal::from_f32(pending_quantity).unwrap_or_default();
+        query_params.insert("pendingQuantity".to_string(), json!(pending_quantity_value));
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = side_effect_type {
-            query_params.insert("side_effect_type".to_string(), json!(rw));
+            query_params.insert("sideEffectType".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = auto_repay_at_cancel {
-            query_params.insert("auto_repay_at_cancel".to_string(), json!(rw));
+            query_params.insert("autoRepayAtCancel".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_client_order_id {
-            query_params.insert("working_client_order_id".to_string(), json!(rw));
+            query_params.insert("workingClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_time_in_force {
-            query_params.insert("working_time_in_force".to_string(), json!(rw));
+            query_params.insert("workingTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_client_order_id {
-            query_params.insert("pending_client_order_id".to_string(), json!(rw));
+            query_params.insert("pendingClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_price {
-            query_params.insert("pending_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_stop_price {
-            query_params.insert("pending_stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingStopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_trailing_delta {
-            query_params.insert("pending_trailing_delta".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingTrailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_iceberg_qty {
-            query_params.insert("pending_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_time_in_force {
-            query_params.insert("pending_time_in_force".to_string(), json!(rw));
+            query_params.insert("pendingTimeInForce".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountNewOtoResponse>(
@@ -2586,102 +2579,114 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("workingSide".to_string(), json!(working_side));
 
-        query_params.insert("workingPrice".to_string(), json!(working_price));
+        let working_price_value = Decimal::from_f32(working_price).unwrap_or_default();
+        query_params.insert("workingPrice".to_string(), json!(working_price_value));
 
-        query_params.insert("workingQuantity".to_string(), json!(working_quantity));
+        let working_quantity_value = Decimal::from_f32(working_quantity).unwrap_or_default();
+        query_params.insert("workingQuantity".to_string(), json!(working_quantity_value));
 
         query_params.insert("pendingSide".to_string(), json!(pending_side));
 
-        query_params.insert("pendingQuantity".to_string(), json!(pending_quantity));
+        let pending_quantity_value = Decimal::from_f32(pending_quantity).unwrap_or_default();
+        query_params.insert("pendingQuantity".to_string(), json!(pending_quantity_value));
 
         query_params.insert("pendingAboveType".to_string(), json!(pending_above_type));
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = side_effect_type {
-            query_params.insert("side_effect_type".to_string(), json!(rw));
+            query_params.insert("sideEffectType".to_string(), json!(rw));
         }
 
         if let Some(rw) = auto_repay_at_cancel {
-            query_params.insert("auto_repay_at_cancel".to_string(), json!(rw));
+            query_params.insert("autoRepayAtCancel".to_string(), json!(rw));
         }
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_client_order_id {
-            query_params.insert("working_client_order_id".to_string(), json!(rw));
+            query_params.insert("workingClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_iceberg_qty {
-            query_params.insert("working_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("workingIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_time_in_force {
-            query_params.insert("working_time_in_force".to_string(), json!(rw));
+            query_params.insert("workingTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_client_order_id {
-            query_params.insert("pending_above_client_order_id".to_string(), json!(rw));
+            query_params.insert("pendingAboveClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_price {
-            query_params.insert("pending_above_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingAbovePrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_stop_price {
-            query_params.insert("pending_above_stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingAboveStopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_trailing_delta {
-            query_params.insert("pending_above_trailing_delta".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingAboveTrailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_iceberg_qty {
-            query_params.insert("pending_above_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingAboveIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_time_in_force {
-            query_params.insert("pending_above_time_in_force".to_string(), json!(rw));
+            query_params.insert("pendingAboveTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_type {
-            query_params.insert("pending_below_type".to_string(), json!(rw));
+            query_params.insert("pendingBelowType".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_client_order_id {
-            query_params.insert("pending_below_client_order_id".to_string(), json!(rw));
+            query_params.insert("pendingBelowClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_price {
-            query_params.insert("pending_below_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingBelowPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_stop_price {
-            query_params.insert("pending_below_stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingBelowStopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_trailing_delta {
-            query_params.insert("pending_below_trailing_delta".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingBelowTrailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_iceberg_qty {
-            query_params.insert("pending_below_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingBelowIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_time_in_force {
-            query_params.insert("pending_below_time_in_force".to_string(), json!(rw));
+            query_params.insert("pendingBelowTimeInForce".to_string(), json!(rw));
         }
 
         send_request::<models::MarginAccountNewOtocoResponse>(
@@ -2718,7 +2723,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginManualLiquidationResponse>(
@@ -2750,7 +2755,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = symbol {
@@ -2758,7 +2763,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryCurrentMarginOrderCountUsageResponseInner>>(
@@ -2793,7 +2798,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = symbol {
@@ -2801,15 +2806,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2817,7 +2822,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryMarginAccountsAllOcoResponseInner>>(
@@ -2855,19 +2860,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2875,7 +2880,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryMarginAccountsAllOrdersResponseInner>>(
@@ -2908,7 +2913,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = symbol {
@@ -2916,15 +2921,15 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = order_list_id {
-            query_params.insert("order_list_id".to_string(), json!(rw));
+            query_params.insert("orderListId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryMarginAccountsOcoResponse>(
@@ -2955,7 +2960,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = symbol {
@@ -2963,7 +2968,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryMarginAccountsOpenOcoResponseInner>>(
@@ -2999,11 +3004,11 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryMarginAccountsOpenOrdersResponseInner>>(
@@ -3038,19 +3043,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryMarginAccountsOrderResponse>(
@@ -3089,23 +3094,23 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = is_isolated {
-            query_params.insert("is_isolated".to_string(), json!(rw));
+            query_params.insert("isIsolated".to_string(), json!(rw));
         }
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -3113,7 +3118,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryMarginAccountsTradeListResponseInner>>(
@@ -3147,7 +3152,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QuerySpecialKeyResponse>(
@@ -3181,7 +3186,7 @@ impl TradeApi for TradeApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QuerySpecialKeyListResponseInner>>(
@@ -3213,7 +3218,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("assetNames".to_string(), json!(asset_names));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Value>(

--- a/src/margin_trading/rest_api/apis/trade_data_stream_api.rs
+++ b/src/margin_trading/rest_api/apis/trade_data_stream_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;

--- a/src/margin_trading/rest_api/apis/transfer_api.rs
+++ b/src/margin_trading/rest_api/apis/transfer_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -105,9 +106,6 @@ pub struct GetCrossMarginTransferHistoryParams {
 impl GetCrossMarginTransferHistoryParams {
     /// Create a builder for [`get_cross_margin_transfer_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetCrossMarginTransferHistoryParamsBuilder {
         GetCrossMarginTransferHistoryParamsBuilder::default()
@@ -175,15 +173,15 @@ impl TransferApi for TransferApiClient {
         }
 
         if let Some(rw) = r#type {
-            query_params.insert("r#type".to_string(), json!(rw));
+            query_params.insert("type".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -195,11 +193,11 @@ impl TransferApi for TransferApiClient {
         }
 
         if let Some(rw) = isolated_symbol {
-            query_params.insert("isolated_symbol".to_string(), json!(rw));
+            query_params.insert("isolatedSymbol".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetCrossMarginTransferHistoryResponse>(
@@ -232,11 +230,11 @@ impl TransferApi for TransferApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = isolated_symbol {
-            query_params.insert("isolated_symbol".to_string(), json!(rw));
+            query_params.insert("isolatedSymbol".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryMaxTransferOutAmountResponse>(

--- a/src/mining/rest_api/apis/mining_api.rs
+++ b/src/mining/rest_api/apis/mining_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -384,9 +385,6 @@ pub struct HashrateResaleListParams {
 impl HashrateResaleListParams {
     /// Create a builder for [`hashrate_resale_list`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> HashrateResaleListParamsBuilder {
         HashrateResaleListParamsBuilder::default()
@@ -690,7 +688,7 @@ impl MiningApi for MiningApiClient {
         query_params.insert("userName".to_string(), json!(user_name));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AccountListResponse>(
@@ -765,7 +763,7 @@ impl MiningApi for MiningApiClient {
         query_params.insert("userName".to_string(), json!(user_name));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CancelHashrateResaleConfigurationResponse>(
@@ -809,23 +807,23 @@ impl MiningApi for MiningApiClient {
         }
 
         if let Some(rw) = start_date {
-            query_params.insert("start_date".to_string(), json!(rw));
+            query_params.insert("startDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_date {
-            query_params.insert("end_date".to_string(), json!(rw));
+            query_params.insert("endDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = page_index {
-            query_params.insert("page_index".to_string(), json!(rw));
+            query_params.insert("pageIndex".to_string(), json!(rw));
         }
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::EarningsListResponse>(
@@ -869,23 +867,23 @@ impl MiningApi for MiningApiClient {
         }
 
         if let Some(rw) = start_date {
-            query_params.insert("start_date".to_string(), json!(rw));
+            query_params.insert("startDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_date {
-            query_params.insert("end_date".to_string(), json!(rw));
+            query_params.insert("endDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = page_index {
-            query_params.insert("page_index".to_string(), json!(rw));
+            query_params.insert("pageIndex".to_string(), json!(rw));
         }
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ExtraBonusListResponse>(
@@ -922,15 +920,15 @@ impl MiningApi for MiningApiClient {
         query_params.insert("userName".to_string(), json!(user_name));
 
         if let Some(rw) = page_index {
-            query_params.insert("page_index".to_string(), json!(rw));
+            query_params.insert("pageIndex".to_string(), json!(rw));
         }
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::HashrateResaleDetailResponse>(
@@ -961,15 +959,15 @@ impl MiningApi for MiningApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = page_index {
-            query_params.insert("page_index".to_string(), json!(rw));
+            query_params.insert("pageIndex".to_string(), json!(rw));
         }
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::HashrateResaleListResponse>(
@@ -1016,7 +1014,7 @@ impl MiningApi for MiningApiClient {
         query_params.insert("hashRate".to_string(), json!(hash_rate));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::HashrateResaleRequestResponse>(
@@ -1052,23 +1050,23 @@ impl MiningApi for MiningApiClient {
         query_params.insert("algo".to_string(), json!(algo));
 
         if let Some(rw) = start_date {
-            query_params.insert("start_date".to_string(), json!(rw));
+            query_params.insert("startDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_date {
-            query_params.insert("end_date".to_string(), json!(rw));
+            query_params.insert("endDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = page_index {
-            query_params.insert("page_index".to_string(), json!(rw));
+            query_params.insert("pageIndex".to_string(), json!(rw));
         }
 
         if let Some(rw) = page_size {
-            query_params.insert("page_size".to_string(), json!(rw));
+            query_params.insert("pageSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MiningAccountEarningResponse>(
@@ -1106,7 +1104,7 @@ impl MiningApi for MiningApiClient {
         query_params.insert("workerName".to_string(), json!(worker_name));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::RequestForDetailMinerListResponse>(
@@ -1145,7 +1143,7 @@ impl MiningApi for MiningApiClient {
         query_params.insert("userName".to_string(), json!(user_name));
 
         if let Some(rw) = page_index {
-            query_params.insert("page_index".to_string(), json!(rw));
+            query_params.insert("pageIndex".to_string(), json!(rw));
         }
 
         if let Some(rw) = sort {
@@ -1153,15 +1151,15 @@ impl MiningApi for MiningApiClient {
         }
 
         if let Some(rw) = sort_column {
-            query_params.insert("sort_column".to_string(), json!(rw));
+            query_params.insert("sortColumn".to_string(), json!(rw));
         }
 
         if let Some(rw) = worker_status {
-            query_params.insert("worker_status".to_string(), json!(rw));
+            query_params.insert("workerStatus".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::RequestForMinerListResponse>(
@@ -1196,7 +1194,7 @@ impl MiningApi for MiningApiClient {
         query_params.insert("userName".to_string(), json!(user_name));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::StatisticListResponse>(

--- a/src/nft/rest_api/apis/nft_api.rs
+++ b/src/nft/rest_api/apis/nft_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -87,9 +88,6 @@ pub struct GetNftAssetParams {
 impl GetNftAssetParams {
     /// Create a builder for [`get_nft_asset`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetNftAssetParamsBuilder {
         GetNftAssetParamsBuilder::default()
@@ -134,9 +132,6 @@ pub struct GetNftDepositHistoryParams {
 
 impl GetNftDepositHistoryParams {
     /// Create a builder for [`get_nft_deposit_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetNftDepositHistoryParamsBuilder {
@@ -237,9 +232,6 @@ pub struct GetNftWithdrawHistoryParams {
 impl GetNftWithdrawHistoryParams {
     /// Create a builder for [`get_nft_withdraw_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetNftWithdrawHistoryParamsBuilder {
         GetNftWithdrawHistoryParamsBuilder::default()
@@ -269,7 +261,7 @@ impl NftApi for NftApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetNftAssetResponse>(
@@ -302,11 +294,11 @@ impl NftApi for NftApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -318,7 +310,7 @@ impl NftApi for NftApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetNftDepositHistoryResponse>(
@@ -354,11 +346,11 @@ impl NftApi for NftApiClient {
         query_params.insert("orderType".to_string(), json!(order_type));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -370,7 +362,7 @@ impl NftApi for NftApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetNftTransactionHistoryResponse>(
@@ -403,11 +395,11 @@ impl NftApi for NftApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -419,7 +411,7 @@ impl NftApi for NftApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetNftWithdrawHistoryResponse>(

--- a/src/pay/rest_api/apis/pay_api.rs
+++ b/src/pay/rest_api/apis/pay_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -82,9 +83,6 @@ pub struct GetPayTradeHistoryParams {
 impl GetPayTradeHistoryParams {
     /// Create a builder for [`get_pay_trade_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetPayTradeHistoryParamsBuilder {
         GetPayTradeHistoryParamsBuilder::default()
@@ -107,11 +105,11 @@ impl PayApi for PayApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -119,7 +117,7 @@ impl PayApi for PayApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetPayTradeHistoryResponse>(

--- a/src/rebate/rest_api/apis/rebate_api.rs
+++ b/src/rebate/rest_api/apis/rebate_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -82,9 +83,6 @@ pub struct GetSpotRebateHistoryRecordsParams {
 impl GetSpotRebateHistoryRecordsParams {
     /// Create a builder for [`get_spot_rebate_history_records`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetSpotRebateHistoryRecordsParamsBuilder {
         GetSpotRebateHistoryRecordsParamsBuilder::default()
@@ -107,11 +105,11 @@ impl RebateApi for RebateApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -119,7 +117,7 @@ impl RebateApi for RebateApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSpotRebateHistoryRecordsResponse>(

--- a/src/simple_earn/rest_api/apis/account_api.rs
+++ b/src/simple_earn/rest_api/apis/account_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -144,9 +145,6 @@ pub struct GetFlexibleProductPositionParams {
 impl GetFlexibleProductPositionParams {
     /// Create a builder for [`get_flexible_product_position`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetFlexibleProductPositionParamsBuilder {
         GetFlexibleProductPositionParamsBuilder::default()
@@ -231,9 +229,6 @@ pub struct GetLockedProductPositionParams {
 impl GetLockedProductPositionParams {
     /// Create a builder for [`get_locked_product_position`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetLockedProductPositionParamsBuilder {
         GetLockedProductPositionParamsBuilder::default()
@@ -272,9 +267,6 @@ pub struct GetSimpleEarnFlexibleProductListParams {
 
 impl GetSimpleEarnFlexibleProductListParams {
     /// Create a builder for [`get_simple_earn_flexible_product_list`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetSimpleEarnFlexibleProductListParamsBuilder {
@@ -315,9 +307,6 @@ pub struct GetSimpleEarnLockedProductListParams {
 impl GetSimpleEarnLockedProductListParams {
     /// Create a builder for [`get_simple_earn_locked_product_list`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetSimpleEarnLockedProductListParamsBuilder {
         GetSimpleEarnLockedProductListParamsBuilder::default()
@@ -341,9 +330,6 @@ pub struct SimpleAccountParams {
 impl SimpleAccountParams {
     /// Create a builder for [`simple_account`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SimpleAccountParamsBuilder {
         SimpleAccountParamsBuilder::default()
@@ -366,7 +352,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("productId".to_string(), json!(product_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexiblePersonalLeftQuotaResponse>(
@@ -403,7 +389,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = product_id {
-            query_params.insert("product_id".to_string(), json!(rw));
+            query_params.insert("productId".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -415,7 +401,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleProductPositionResponse>(
@@ -447,7 +433,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("projectId".to_string(), json!(project_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetLockedPersonalLeftQuotaResponse>(
@@ -485,11 +471,11 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = position_id {
-            query_params.insert("position_id".to_string(), json!(rw));
+            query_params.insert("positionId".to_string(), json!(rw));
         }
 
         if let Some(rw) = project_id {
-            query_params.insert("project_id".to_string(), json!(rw));
+            query_params.insert("projectId".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -501,7 +487,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetLockedProductPositionResponse>(
@@ -545,7 +531,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSimpleEarnFlexibleProductListResponse>(
@@ -589,7 +575,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSimpleEarnLockedProductListResponse>(
@@ -616,7 +602,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SimpleAccountResponse>(

--- a/src/simple_earn/rest_api/apis/earn_api.rs
+++ b/src/simple_earn/rest_api/apis/earn_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -507,10 +508,11 @@ impl EarnApi for EarnApiClient {
 
         query_params.insert("productId".to_string(), json!(product_id));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleSubscriptionPreviewResponse>(
@@ -544,14 +546,15 @@ impl EarnApi for EarnApiClient {
 
         query_params.insert("projectId".to_string(), json!(project_id));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = auto_subscribe {
-            query_params.insert("auto_subscribe".to_string(), json!(rw));
+            query_params.insert("autoSubscribe".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetLockedSubscriptionPreviewResponseInner>>(
@@ -586,19 +589,20 @@ impl EarnApi for EarnApiClient {
         query_params.insert("productId".to_string(), json!(product_id));
 
         if let Some(rw) = redeem_all {
-            query_params.insert("redeem_all".to_string(), json!(rw));
+            query_params.insert("redeemAll".to_string(), json!(rw));
         }
 
         if let Some(rw) = amount {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("amount".to_string(), json!(rw));
         }
 
         if let Some(rw) = dest_account {
-            query_params.insert("dest_account".to_string(), json!(rw));
+            query_params.insert("destAccount".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::RedeemFlexibleProductResponse>(
@@ -630,7 +634,7 @@ impl EarnApi for EarnApiClient {
         query_params.insert("positionId".to_string(), json!(position_id));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::RedeemLockedProductResponse>(
@@ -665,7 +669,7 @@ impl EarnApi for EarnApiClient {
         query_params.insert("autoSubscribe".to_string(), json!(auto_subscribe));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SetFlexibleAutoSubscribeResponse>(
@@ -700,7 +704,7 @@ impl EarnApi for EarnApiClient {
         query_params.insert("autoSubscribe".to_string(), json!(auto_subscribe));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SetLockedAutoSubscribeResponse>(
@@ -735,7 +739,7 @@ impl EarnApi for EarnApiClient {
         query_params.insert("redeemTo".to_string(), json!(redeem_to));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SetLockedProductRedeemOptionResponse>(
@@ -769,18 +773,19 @@ impl EarnApi for EarnApiClient {
 
         query_params.insert("productId".to_string(), json!(product_id));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = auto_subscribe {
-            query_params.insert("auto_subscribe".to_string(), json!(rw));
+            query_params.insert("autoSubscribe".to_string(), json!(rw));
         }
 
         if let Some(rw) = source_account {
-            query_params.insert("source_account".to_string(), json!(rw));
+            query_params.insert("sourceAccount".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SubscribeFlexibleProductResponse>(
@@ -815,22 +820,23 @@ impl EarnApi for EarnApiClient {
 
         query_params.insert("projectId".to_string(), json!(project_id));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = auto_subscribe {
-            query_params.insert("auto_subscribe".to_string(), json!(rw));
+            query_params.insert("autoSubscribe".to_string(), json!(rw));
         }
 
         if let Some(rw) = source_account {
-            query_params.insert("source_account".to_string(), json!(rw));
+            query_params.insert("sourceAccount".to_string(), json!(rw));
         }
 
         if let Some(rw) = redeem_to {
-            query_params.insert("redeem_to".to_string(), json!(rw));
+            query_params.insert("redeemTo".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SubscribeLockedProductResponse>(

--- a/src/simple_earn/rest_api/apis/history_api.rs
+++ b/src/simple_earn/rest_api/apis/history_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -121,9 +122,6 @@ pub struct GetCollateralRecordParams {
 impl GetCollateralRecordParams {
     /// Create a builder for [`get_collateral_record`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetCollateralRecordParamsBuilder {
         GetCollateralRecordParamsBuilder::default()
@@ -186,9 +184,6 @@ pub struct GetFlexibleRedemptionRecordParams {
 
 impl GetFlexibleRedemptionRecordParams {
     /// Create a builder for [`get_flexible_redemption_record`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetFlexibleRedemptionRecordParamsBuilder {
@@ -319,9 +314,6 @@ pub struct GetFlexibleSubscriptionRecordParams {
 impl GetFlexibleSubscriptionRecordParams {
     /// Create a builder for [`get_flexible_subscription_record`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetFlexibleSubscriptionRecordParamsBuilder {
         GetFlexibleSubscriptionRecordParamsBuilder::default()
@@ -385,9 +377,6 @@ pub struct GetLockedRedemptionRecordParams {
 impl GetLockedRedemptionRecordParams {
     /// Create a builder for [`get_locked_redemption_record`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetLockedRedemptionRecordParamsBuilder {
         GetLockedRedemptionRecordParamsBuilder::default()
@@ -445,9 +434,6 @@ pub struct GetLockedRewardsHistoryParams {
 impl GetLockedRewardsHistoryParams {
     /// Create a builder for [`get_locked_rewards_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetLockedRewardsHistoryParamsBuilder {
         GetLockedRewardsHistoryParamsBuilder::default()
@@ -504,9 +490,6 @@ pub struct GetLockedSubscriptionRecordParams {
 
 impl GetLockedSubscriptionRecordParams {
     /// Create a builder for [`get_locked_subscription_record`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetLockedSubscriptionRecordParamsBuilder {
@@ -592,15 +575,15 @@ impl HistoryApi for HistoryApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = product_id {
-            query_params.insert("product_id".to_string(), json!(rw));
+            query_params.insert("productId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -612,7 +595,7 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetCollateralRecordResponse>(
@@ -648,11 +631,11 @@ impl HistoryApi for HistoryApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = product_id {
-            query_params.insert("product_id".to_string(), json!(rw));
+            query_params.insert("productId".to_string(), json!(rw));
         }
 
         if let Some(rw) = redeem_id {
-            query_params.insert("redeem_id".to_string(), json!(rw));
+            query_params.insert("redeemId".to_string(), json!(rw));
         }
 
         if let Some(rw) = asset {
@@ -660,11 +643,11 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -676,7 +659,7 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleRedemptionRecordResponse>(
@@ -714,7 +697,7 @@ impl HistoryApi for HistoryApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = product_id {
-            query_params.insert("product_id".to_string(), json!(rw));
+            query_params.insert("productId".to_string(), json!(rw));
         }
 
         if let Some(rw) = asset {
@@ -722,11 +705,11 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -738,7 +721,7 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleRewardsHistoryResponse>(
@@ -774,11 +757,11 @@ impl HistoryApi for HistoryApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = product_id {
-            query_params.insert("product_id".to_string(), json!(rw));
+            query_params.insert("productId".to_string(), json!(rw));
         }
 
         if let Some(rw) = purchase_id {
-            query_params.insert("purchase_id".to_string(), json!(rw));
+            query_params.insert("purchaseId".to_string(), json!(rw));
         }
 
         if let Some(rw) = asset {
@@ -786,11 +769,11 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -802,7 +785,7 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFlexibleSubscriptionRecordResponse>(
@@ -838,11 +821,11 @@ impl HistoryApi for HistoryApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = position_id {
-            query_params.insert("position_id".to_string(), json!(rw));
+            query_params.insert("positionId".to_string(), json!(rw));
         }
 
         if let Some(rw) = redeem_id {
-            query_params.insert("redeem_id".to_string(), json!(rw));
+            query_params.insert("redeemId".to_string(), json!(rw));
         }
 
         if let Some(rw) = asset {
@@ -850,11 +833,11 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -866,7 +849,7 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetLockedRedemptionRecordResponse>(
@@ -901,7 +884,7 @@ impl HistoryApi for HistoryApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = position_id {
-            query_params.insert("position_id".to_string(), json!(rw));
+            query_params.insert("positionId".to_string(), json!(rw));
         }
 
         if let Some(rw) = asset {
@@ -909,11 +892,11 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -925,7 +908,7 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetLockedRewardsHistoryResponse>(
@@ -960,7 +943,7 @@ impl HistoryApi for HistoryApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = purchase_id {
-            query_params.insert("purchase_id".to_string(), json!(rw));
+            query_params.insert("purchaseId".to_string(), json!(rw));
         }
 
         if let Some(rw) = asset {
@@ -968,11 +951,11 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -984,7 +967,7 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetLockedSubscriptionRecordResponse>(
@@ -1021,15 +1004,15 @@ impl HistoryApi for HistoryApiClient {
         query_params.insert("productId".to_string(), json!(product_id));
 
         if let Some(rw) = apr_period {
-            query_params.insert("apr_period".to_string(), json!(rw));
+            query_params.insert("aprPeriod".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -1041,7 +1024,7 @@ impl HistoryApi for HistoryApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetRateHistoryResponse>(

--- a/src/spot/rest_api/apis/account_api.rs
+++ b/src/spot/rest_api/apis/account_api.rs
@@ -20,6 +20,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -164,9 +165,6 @@ pub struct AllOrderListParams {
 impl AllOrderListParams {
     /// Create a builder for [`all_order_list`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AllOrderListParamsBuilder {
         AllOrderListParamsBuilder::default()
@@ -247,9 +245,6 @@ pub struct GetAccountParams {
 impl GetAccountParams {
     /// Create a builder for [`get_account`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetAccountParamsBuilder {
         GetAccountParamsBuilder::default()
@@ -276,9 +271,6 @@ pub struct GetOpenOrdersParams {
 
 impl GetOpenOrdersParams {
     /// Create a builder for [`get_open_orders`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetOpenOrdersParamsBuilder {
@@ -356,9 +348,6 @@ pub struct GetOrderListParams {
 
 impl GetOrderListParams {
     /// Create a builder for [`get_order_list`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetOrderListParamsBuilder {
@@ -554,9 +543,6 @@ pub struct OpenOrderListParams {
 impl OpenOrderListParams {
     /// Create a builder for [`open_order_list`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> OpenOrderListParamsBuilder {
         OpenOrderListParamsBuilder::default()
@@ -631,9 +617,6 @@ pub struct RateLimitOrderParams {
 impl RateLimitOrderParams {
     /// Create a builder for [`rate_limit_order`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> RateLimitOrderParamsBuilder {
         RateLimitOrderParamsBuilder::default()
@@ -682,15 +665,15 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -698,7 +681,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AllOrderListResponseInner>>(
@@ -734,15 +717,15 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -750,7 +733,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AllOrdersResponseInner>>(
@@ -780,11 +763,11 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = omit_zero_balances {
-            query_params.insert("omit_zero_balances".to_string(), json!(rw));
+            query_params.insert("omitZeroBalances".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetAccountResponse>(
@@ -818,7 +801,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AllOrdersResponseInner>>(
@@ -852,15 +835,15 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetOrderResponse>(
@@ -891,15 +874,15 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = order_list_id {
-            query_params.insert("order_list_id".to_string(), json!(rw));
+            query_params.insert("orderListId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetOrderListResponse>(
@@ -936,15 +919,15 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = from_allocation_id {
-            query_params.insert("from_allocation_id".to_string(), json!(rw));
+            query_params.insert("fromAllocationId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -952,11 +935,11 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::MyAllocationsResponseInner>>(
@@ -992,15 +975,15 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = prevented_match_id {
-            query_params.insert("prevented_match_id".to_string(), json!(rw));
+            query_params.insert("preventedMatchId".to_string(), json!(rw));
         }
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = from_prevented_match_id {
-            query_params.insert("from_prevented_match_id".to_string(), json!(rw));
+            query_params.insert("fromPreventedMatchId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1008,7 +991,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::MyPreventedMatchesResponseInner>>(
@@ -1045,19 +1028,19 @@ impl AccountApi for AccountApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1065,7 +1048,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::MyTradesResponseInner>>(
@@ -1092,7 +1075,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::OpenOrderListResponseInner>>(
@@ -1129,7 +1112,7 @@ impl AccountApi for AccountApiClient {
         query_params.insert("orderId".to_string(), json!(order_id));
 
         if let Some(rw) = from_execution_id {
-            query_params.insert("from_execution_id".to_string(), json!(rw));
+            query_params.insert("fromExecutionId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1137,7 +1120,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::OrderAmendmentsResponseInner>>(
@@ -1164,7 +1147,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::RateLimitOrderResponseInner>>(

--- a/src/spot/rest_api/apis/general_api.rs
+++ b/src/spot/rest_api/apis/general_api.rs
@@ -20,6 +20,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -120,9 +121,6 @@ pub struct ExchangeInfoParams {
 impl ExchangeInfoParams {
     /// Create a builder for [`exchange_info`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> ExchangeInfoParamsBuilder {
         ExchangeInfoParamsBuilder::default()
@@ -158,11 +156,11 @@ impl GeneralApi for GeneralApiClient {
         }
 
         if let Some(rw) = show_permission_sets {
-            query_params.insert("show_permission_sets".to_string(), json!(rw));
+            query_params.insert("showPermissionSets".to_string(), json!(rw));
         }
 
         if let Some(rw) = symbol_status {
-            query_params.insert("symbol_status".to_string(), json!(rw));
+            query_params.insert("symbolStatus".to_string(), json!(rw));
         }
 
         send_request::<models::ExchangeInfoResponse>(

--- a/src/spot/rest_api/apis/market_api.rs
+++ b/src/spot/rest_api/apis/market_api.rs
@@ -20,6 +20,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -817,9 +818,6 @@ pub struct TickerParams {
 impl TickerParams {
     /// Create a builder for [`ticker`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> TickerParamsBuilder {
         TickerParamsBuilder::default()
@@ -853,9 +851,6 @@ pub struct Ticker24hrParams {
 impl Ticker24hrParams {
     /// Create a builder for [`ticker24hr`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> Ticker24hrParamsBuilder {
         Ticker24hrParamsBuilder::default()
@@ -883,9 +878,6 @@ pub struct TickerBookTickerParams {
 impl TickerBookTickerParams {
     /// Create a builder for [`ticker_book_ticker`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> TickerBookTickerParamsBuilder {
         TickerBookTickerParamsBuilder::default()
@@ -912,9 +904,6 @@ pub struct TickerPriceParams {
 
 impl TickerPriceParams {
     /// Create a builder for [`ticker_price`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> TickerPriceParamsBuilder {
@@ -953,9 +942,6 @@ pub struct TickerTradingDayParams {
 
 impl TickerTradingDayParams {
     /// Create a builder for [`ticker_trading_day`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> TickerTradingDayParamsBuilder {
@@ -1038,15 +1024,15 @@ impl MarketApi for MarketApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1170,7 +1156,7 @@ impl MarketApi for MarketApiClient {
         }
 
         if let Some(rw) = from_id {
-            query_params.insert("from_id".to_string(), json!(rw));
+            query_params.insert("fromId".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::HistoricalTradesResponseInner>>(
@@ -1208,15 +1194,15 @@ impl MarketApi for MarketApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_zone {
-            query_params.insert("time_zone".to_string(), json!(rw));
+            query_params.insert("timeZone".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1260,11 +1246,11 @@ impl MarketApi for MarketApiClient {
         }
 
         if let Some(rw) = window_size {
-            query_params.insert("window_size".to_string(), json!(rw));
+            query_params.insert("windowSize".to_string(), json!(rw));
         }
 
         if let Some(rw) = r#type {
-            query_params.insert("r#type".to_string(), json!(rw));
+            query_params.insert("type".to_string(), json!(rw));
         }
 
         send_request::<models::TickerResponse>(
@@ -1303,7 +1289,7 @@ impl MarketApi for MarketApiClient {
         }
 
         if let Some(rw) = r#type {
-            query_params.insert("r#type".to_string(), json!(rw));
+            query_params.insert("type".to_string(), json!(rw));
         }
 
         send_request::<models::Ticker24hrResponse>(
@@ -1405,11 +1391,11 @@ impl MarketApi for MarketApiClient {
         }
 
         if let Some(rw) = time_zone {
-            query_params.insert("time_zone".to_string(), json!(rw));
+            query_params.insert("timeZone".to_string(), json!(rw));
         }
 
         if let Some(rw) = r#type {
-            query_params.insert("r#type".to_string(), json!(rw));
+            query_params.insert("type".to_string(), json!(rw));
         }
 
         send_request::<models::TickerTradingDayResponse>(
@@ -1447,15 +1433,15 @@ impl MarketApi for MarketApiClient {
         query_params.insert("interval".to_string(), json!(interval));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = time_zone {
-            query_params.insert("time_zone".to_string(), json!(rw));
+            query_params.insert("timeZone".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {

--- a/src/spot/rest_api/apis/trade_api.rs
+++ b/src/spot/rest_api/apis/trade_api.rs
@@ -20,6 +20,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -2502,9 +2503,6 @@ pub struct OrderTestParams {
 impl OrderTestParams {
     /// Create a builder for [`order_test`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> OrderTestParamsBuilder {
         OrderTestParamsBuilder::default()
@@ -2634,9 +2632,6 @@ pub struct SorOrderTestParams {
 impl SorOrderTestParams {
     /// Create a builder for [`sor_order_test`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SorOrderTestParamsBuilder {
         SorOrderTestParamsBuilder::default()
@@ -2659,7 +2654,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::DeleteOpenOrdersResponseInner>>(
@@ -2695,23 +2690,23 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = cancel_restrictions {
-            query_params.insert("cancel_restrictions".to_string(), json!(rw));
+            query_params.insert("cancelRestrictions".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::DeleteOrderResponse>(
@@ -2746,19 +2741,19 @@ impl TradeApi for TradeApiClient {
         query_params.insert("symbol".to_string(), json!(symbol));
 
         if let Some(rw) = order_list_id {
-            query_params.insert("order_list_id".to_string(), json!(rw));
+            query_params.insert("orderListId".to_string(), json!(rw));
         }
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::DeleteOrderListResponse>(
@@ -2808,55 +2803,60 @@ impl TradeApi for TradeApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = quote_order_qty {
-            query_params.insert("quote_order_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("quoteOrderQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = strategy_type {
-            query_params.insert("strategy_type".to_string(), json!(rw));
+            query_params.insert("strategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_price {
-            query_params.insert("stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = trailing_delta {
-            query_params.insert("trailing_delta".to_string(), json!(rw));
+            query_params.insert("trailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = iceberg_qty {
-            query_params.insert("iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("icebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::NewOrderResponse>(
@@ -2891,22 +2891,23 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("symbol".to_string(), json!(symbol));
 
-        query_params.insert("newQty".to_string(), json!(new_qty));
+        let new_qty_value = Decimal::from_f32(new_qty).unwrap_or_default();
+        query_params.insert("newQty".to_string(), json!(new_qty_value));
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = orig_client_order_id {
-            query_params.insert("orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("origClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::OrderAmendKeepPriorityResponse>(
@@ -2964,75 +2965,80 @@ impl TradeApi for TradeApiClient {
         query_params.insert("cancelReplaceMode".to_string(), json!(cancel_replace_mode));
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = quantity {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("quantity".to_string(), json!(rw));
         }
 
         if let Some(rw) = quote_order_qty {
-            query_params.insert("quote_order_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("quoteOrderQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = cancel_new_client_order_id {
-            query_params.insert("cancel_new_client_order_id".to_string(), json!(rw));
+            query_params.insert("cancelNewClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = cancel_orig_client_order_id {
-            query_params.insert("cancel_orig_client_order_id".to_string(), json!(rw));
+            query_params.insert("cancelOrigClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = cancel_order_id {
-            query_params.insert("cancel_order_id".to_string(), json!(rw));
+            query_params.insert("cancelOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = strategy_type {
-            query_params.insert("strategy_type".to_string(), json!(rw));
+            query_params.insert("strategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_price {
-            query_params.insert("stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = trailing_delta {
-            query_params.insert("trailing_delta".to_string(), json!(rw));
+            query_params.insert("trailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = iceberg_qty {
-            query_params.insert("iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("icebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = cancel_restrictions {
-            query_params.insert("cancel_restrictions".to_string(), json!(rw));
+            query_params.insert("cancelRestrictions".to_string(), json!(rw));
         }
 
         if let Some(rw) = order_rate_limit_exceeded_mode {
-            query_params.insert("order_rate_limit_exceeded_mode".to_string(), json!(rw));
+            query_params.insert("orderRateLimitExceededMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::OrderCancelReplaceResponse>(
@@ -3088,90 +3094,96 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
         query_params.insert("aboveType".to_string(), json!(above_type));
 
         query_params.insert("belowType".to_string(), json!(below_type));
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = above_client_order_id {
-            query_params.insert("above_client_order_id".to_string(), json!(rw));
+            query_params.insert("aboveClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = above_iceberg_qty {
-            query_params.insert("above_iceberg_qty".to_string(), json!(rw));
+            query_params.insert("aboveIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = above_price {
-            query_params.insert("above_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("abovePrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = above_stop_price {
-            query_params.insert("above_stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("aboveStopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = above_trailing_delta {
-            query_params.insert("above_trailing_delta".to_string(), json!(rw));
+            query_params.insert("aboveTrailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = above_time_in_force {
-            query_params.insert("above_time_in_force".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("aboveTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = above_strategy_id {
-            query_params.insert("above_strategy_id".to_string(), json!(rw));
+            query_params.insert("aboveStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = above_strategy_type {
-            query_params.insert("above_strategy_type".to_string(), json!(rw));
+            query_params.insert("aboveStrategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = below_client_order_id {
-            query_params.insert("below_client_order_id".to_string(), json!(rw));
+            query_params.insert("belowClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = below_iceberg_qty {
-            query_params.insert("below_iceberg_qty".to_string(), json!(rw));
+            query_params.insert("belowIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = below_price {
-            query_params.insert("below_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("belowPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = below_stop_price {
-            query_params.insert("below_stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("belowStopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = below_trailing_delta {
-            query_params.insert("below_trailing_delta".to_string(), json!(rw));
+            query_params.insert("belowTrailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = below_time_in_force {
-            query_params.insert("below_time_in_force".to_string(), json!(rw));
+            query_params.insert("belowTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = below_strategy_id {
-            query_params.insert("below_strategy_id".to_string(), json!(rw));
+            query_params.insert("belowStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = below_strategy_type {
-            query_params.insert("below_strategy_type".to_string(), json!(rw));
+            query_params.insert("belowStrategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::OrderListOcoResponse>(
@@ -3229,82 +3241,90 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("workingSide".to_string(), json!(working_side));
 
-        query_params.insert("workingPrice".to_string(), json!(working_price));
+        let working_price_value = Decimal::from_f32(working_price).unwrap_or_default();
+        query_params.insert("workingPrice".to_string(), json!(working_price_value));
 
-        query_params.insert("workingQuantity".to_string(), json!(working_quantity));
+        let working_quantity_value = Decimal::from_f32(working_quantity).unwrap_or_default();
+        query_params.insert("workingQuantity".to_string(), json!(working_quantity_value));
 
         query_params.insert("pendingType".to_string(), json!(pending_type));
 
         query_params.insert("pendingSide".to_string(), json!(pending_side));
 
-        query_params.insert("pendingQuantity".to_string(), json!(pending_quantity));
+        let pending_quantity_value = Decimal::from_f32(pending_quantity).unwrap_or_default();
+        query_params.insert("pendingQuantity".to_string(), json!(pending_quantity_value));
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_client_order_id {
-            query_params.insert("working_client_order_id".to_string(), json!(rw));
+            query_params.insert("workingClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_iceberg_qty {
-            query_params.insert("working_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("workingIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_time_in_force {
-            query_params.insert("working_time_in_force".to_string(), json!(rw));
+            query_params.insert("workingTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_strategy_id {
-            query_params.insert("working_strategy_id".to_string(), json!(rw));
+            query_params.insert("workingStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_strategy_type {
-            query_params.insert("working_strategy_type".to_string(), json!(rw));
+            query_params.insert("workingStrategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_client_order_id {
-            query_params.insert("pending_client_order_id".to_string(), json!(rw));
+            query_params.insert("pendingClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_price {
-            query_params.insert("pending_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_stop_price {
-            query_params.insert("pending_stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingStopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_trailing_delta {
-            query_params.insert("pending_trailing_delta".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingTrailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_iceberg_qty {
-            query_params.insert("pending_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_time_in_force {
-            query_params.insert("pending_time_in_force".to_string(), json!(rw));
+            query_params.insert("pendingTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_strategy_id {
-            query_params.insert("pending_strategy_id".to_string(), json!(rw));
+            query_params.insert("pendingStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_strategy_type {
-            query_params.insert("pending_strategy_type".to_string(), json!(rw));
+            query_params.insert("pendingStrategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::OrderListOtoResponse>(
@@ -3371,118 +3391,130 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("workingSide".to_string(), json!(working_side));
 
-        query_params.insert("workingPrice".to_string(), json!(working_price));
+        let working_price_value = Decimal::from_f32(working_price).unwrap_or_default();
+        query_params.insert("workingPrice".to_string(), json!(working_price_value));
 
-        query_params.insert("workingQuantity".to_string(), json!(working_quantity));
+        let working_quantity_value = Decimal::from_f32(working_quantity).unwrap_or_default();
+        query_params.insert("workingQuantity".to_string(), json!(working_quantity_value));
 
         query_params.insert("pendingSide".to_string(), json!(pending_side));
 
-        query_params.insert("pendingQuantity".to_string(), json!(pending_quantity));
+        let pending_quantity_value = Decimal::from_f32(pending_quantity).unwrap_or_default();
+        query_params.insert("pendingQuantity".to_string(), json!(pending_quantity_value));
 
         query_params.insert("pendingAboveType".to_string(), json!(pending_above_type));
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_client_order_id {
-            query_params.insert("working_client_order_id".to_string(), json!(rw));
+            query_params.insert("workingClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_iceberg_qty {
-            query_params.insert("working_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("workingIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_time_in_force {
-            query_params.insert("working_time_in_force".to_string(), json!(rw));
+            query_params.insert("workingTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_strategy_id {
-            query_params.insert("working_strategy_id".to_string(), json!(rw));
+            query_params.insert("workingStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = working_strategy_type {
-            query_params.insert("working_strategy_type".to_string(), json!(rw));
+            query_params.insert("workingStrategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_client_order_id {
-            query_params.insert("pending_above_client_order_id".to_string(), json!(rw));
+            query_params.insert("pendingAboveClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_price {
-            query_params.insert("pending_above_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingAbovePrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_stop_price {
-            query_params.insert("pending_above_stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingAboveStopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_trailing_delta {
-            query_params.insert("pending_above_trailing_delta".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingAboveTrailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_iceberg_qty {
-            query_params.insert("pending_above_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingAboveIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_time_in_force {
-            query_params.insert("pending_above_time_in_force".to_string(), json!(rw));
+            query_params.insert("pendingAboveTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_strategy_id {
-            query_params.insert("pending_above_strategy_id".to_string(), json!(rw));
+            query_params.insert("pendingAboveStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_above_strategy_type {
-            query_params.insert("pending_above_strategy_type".to_string(), json!(rw));
+            query_params.insert("pendingAboveStrategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_type {
-            query_params.insert("pending_below_type".to_string(), json!(rw));
+            query_params.insert("pendingBelowType".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_client_order_id {
-            query_params.insert("pending_below_client_order_id".to_string(), json!(rw));
+            query_params.insert("pendingBelowClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_price {
-            query_params.insert("pending_below_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingBelowPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_stop_price {
-            query_params.insert("pending_below_stop_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingBelowStopPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_trailing_delta {
-            query_params.insert("pending_below_trailing_delta".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingBelowTrailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_iceberg_qty {
-            query_params.insert("pending_below_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("pendingBelowIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_time_in_force {
-            query_params.insert("pending_below_time_in_force".to_string(), json!(rw));
+            query_params.insert("pendingBelowTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_strategy_id {
-            query_params.insert("pending_below_strategy_id".to_string(), json!(rw));
+            query_params.insert("pendingBelowStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_below_strategy_type {
-            query_params.insert("pending_below_strategy_type".to_string(), json!(rw));
+            query_params.insert("pendingBelowStrategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::OrderListOtocoResponse>(
@@ -3533,70 +3565,76 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("side".to_string(), json!(side));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
-        query_params.insert("price".to_string(), json!(price));
+        let price_value = Decimal::from_f32(price).unwrap_or_default();
+        query_params.insert("price".to_string(), json!(price_value));
 
-        query_params.insert("stopPrice".to_string(), json!(stop_price));
+        let stop_price_value = Decimal::from_f32(stop_price).unwrap_or_default();
+        query_params.insert("stopPrice".to_string(), json!(stop_price_value));
 
         if let Some(rw) = list_client_order_id {
-            query_params.insert("list_client_order_id".to_string(), json!(rw));
+            query_params.insert("listClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_client_order_id {
-            query_params.insert("limit_client_order_id".to_string(), json!(rw));
+            query_params.insert("limitClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_strategy_id {
-            query_params.insert("limit_strategy_id".to_string(), json!(rw));
+            query_params.insert("limitStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_strategy_type {
-            query_params.insert("limit_strategy_type".to_string(), json!(rw));
+            query_params.insert("limitStrategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit_iceberg_qty {
-            query_params.insert("limit_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("limitIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = trailing_delta {
-            query_params.insert("trailing_delta".to_string(), json!(rw));
+            query_params.insert("trailingDelta".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_client_order_id {
-            query_params.insert("stop_client_order_id".to_string(), json!(rw));
+            query_params.insert("stopClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_strategy_id {
-            query_params.insert("stop_strategy_id".to_string(), json!(rw));
+            query_params.insert("stopStrategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_strategy_type {
-            query_params.insert("stop_strategy_type".to_string(), json!(rw));
+            query_params.insert("stopStrategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_limit_price {
-            query_params.insert("stop_limit_price".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopLimitPrice".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_iceberg_qty {
-            query_params.insert("stop_iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("stopIcebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = stop_limit_time_in_force {
-            query_params.insert("stop_limit_time_in_force".to_string(), json!(rw));
+            query_params.insert("stopLimitTimeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::OrderOcoResponse>(
@@ -3625,7 +3663,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = compute_commission_rates {
-            query_params.insert("compute_commission_rates".to_string(), json!(rw));
+            query_params.insert("computeCommissionRates".to_string(), json!(rw));
         }
 
         send_request::<models::OrderTestResponse>(
@@ -3671,42 +3709,45 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("type".to_string(), json!(r#type));
 
-        query_params.insert("quantity".to_string(), json!(quantity));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        query_params.insert("quantity".to_string(), json!(quantity_value));
 
         if let Some(rw) = time_in_force {
-            query_params.insert("time_in_force".to_string(), json!(rw));
+            query_params.insert("timeInForce".to_string(), json!(rw));
         }
 
         if let Some(rw) = price {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("price".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_client_order_id {
-            query_params.insert("new_client_order_id".to_string(), json!(rw));
+            query_params.insert("newClientOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = strategy_id {
-            query_params.insert("strategy_id".to_string(), json!(rw));
+            query_params.insert("strategyId".to_string(), json!(rw));
         }
 
         if let Some(rw) = strategy_type {
-            query_params.insert("strategy_type".to_string(), json!(rw));
+            query_params.insert("strategyType".to_string(), json!(rw));
         }
 
         if let Some(rw) = iceberg_qty {
-            query_params.insert("iceberg_qty".to_string(), json!(rw));
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
+            query_params.insert("icebergQty".to_string(), json!(rw));
         }
 
         if let Some(rw) = new_order_resp_type {
-            query_params.insert("new_order_resp_type".to_string(), json!(rw));
+            query_params.insert("newOrderRespType".to_string(), json!(rw));
         }
 
         if let Some(rw) = self_trade_prevention_mode {
-            query_params.insert("self_trade_prevention_mode".to_string(), json!(rw));
+            query_params.insert("selfTradePreventionMode".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SorOrderResponse>(
@@ -3735,7 +3776,7 @@ impl TradeApi for TradeApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = compute_commission_rates {
-            query_params.insert("compute_commission_rates".to_string(), json!(rw));
+            query_params.insert("computeCommissionRates".to_string(), json!(rw));
         }
 
         send_request::<models::SorOrderTestResponse>(

--- a/src/spot/rest_api/apis/user_data_stream_api.rs
+++ b/src/spot/rest_api/apis/user_data_stream_api.rs
@@ -20,6 +20,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;

--- a/src/spot/websocket_api/apis/account_api.rs
+++ b/src/spot/websocket_api/apis/account_api.rs
@@ -20,6 +20,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -151,9 +152,6 @@ pub struct AccountRateLimitsOrdersParams {
 impl AccountRateLimitsOrdersParams {
     /// Create a builder for [`account_rate_limits_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AccountRateLimitsOrdersParamsBuilder {
         AccountRateLimitsOrdersParamsBuilder::default()
@@ -185,9 +183,6 @@ pub struct AccountStatusParams {
 
 impl AccountStatusParams {
     /// Create a builder for [`account_status`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AccountStatusParamsBuilder {
@@ -237,9 +232,6 @@ pub struct AllOrderListsParams {
 
 impl AllOrderListsParams {
     /// Create a builder for [`all_order_lists`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AllOrderListsParamsBuilder {
@@ -515,9 +507,6 @@ pub struct OpenOrderListsStatusParams {
 impl OpenOrderListsStatusParams {
     /// Create a builder for [`open_order_lists_status`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> OpenOrderListsStatusParamsBuilder {
         OpenOrderListsStatusParamsBuilder::default()
@@ -549,9 +538,6 @@ pub struct OpenOrdersStatusParams {
 
 impl OpenOrdersStatusParams {
     /// Create a builder for [`open_orders_status`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> OpenOrdersStatusParamsBuilder {
@@ -647,9 +633,6 @@ pub struct OrderListStatusParams {
 impl OrderListStatusParams {
     /// Create a builder for [`order_list_status`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> OrderListStatusParamsBuilder {
         OrderListStatusParamsBuilder::default()
@@ -712,6 +695,7 @@ impl AccountApi for AccountApiClient {
         let AccountCommissionParams { symbol, id } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
@@ -743,7 +727,7 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -775,10 +759,10 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = omit_zero_balances {
-            payload.insert("omit_zero_balances".to_string(), serde_json::json!(value));
+            payload.insert("omitZeroBalances".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -813,19 +797,19 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = from_id {
-            payload.insert("from_id".to_string(), serde_json::json!(value));
+            payload.insert("fromId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = start_time {
-            payload.insert("start_time".to_string(), serde_json::json!(value));
+            payload.insert("startTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = end_time {
-            payload.insert("end_time".to_string(), serde_json::json!(value));
+            payload.insert("endTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit {
             payload.insert("limit".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -857,24 +841,25 @@ impl AccountApi for AccountApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = start_time {
-            payload.insert("start_time".to_string(), serde_json::json!(value));
+            payload.insert("startTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = end_time {
-            payload.insert("end_time".to_string(), serde_json::json!(value));
+            payload.insert("endTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit {
             payload.insert("limit".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -907,27 +892,28 @@ impl AccountApi for AccountApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = start_time {
-            payload.insert("start_time".to_string(), serde_json::json!(value));
+            payload.insert("startTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = end_time {
-            payload.insert("end_time".to_string(), serde_json::json!(value));
+            payload.insert("endTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = from_allocation_id {
-            payload.insert("from_allocation_id".to_string(), serde_json::json!(value));
+            payload.insert("fromAllocationId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit {
             payload.insert("limit".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -960,27 +946,25 @@ impl AccountApi for AccountApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = prevented_match_id {
-            payload.insert("prevented_match_id".to_string(), serde_json::json!(value));
+            payload.insert("preventedMatchId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = from_prevented_match_id {
-            payload.insert(
-                "from_prevented_match_id".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("fromPreventedMatchId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit {
             payload.insert("limit".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -1013,27 +997,28 @@ impl AccountApi for AccountApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = start_time {
-            payload.insert("start_time".to_string(), serde_json::json!(value));
+            payload.insert("startTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = end_time {
-            payload.insert("end_time".to_string(), serde_json::json!(value));
+            payload.insert("endTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = from_id {
-            payload.insert("from_id".to_string(), serde_json::json!(value));
+            payload.insert("fromId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit {
             payload.insert("limit".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -1062,7 +1047,7 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -1098,7 +1083,7 @@ impl AccountApi for AccountApiClient {
             payload.insert("symbol".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -1129,19 +1114,21 @@ impl AccountApi for AccountApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
-        payload.insert("order_id".to_string(), serde_json::json!(order_id));
+
+        payload.insert("orderId".to_string(), serde_json::json!(order_id));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = from_execution_id {
-            payload.insert("from_execution_id".to_string(), serde_json::json!(value));
+            payload.insert("fromExecutionId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit {
             payload.insert("limit".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -1174,13 +1161,13 @@ impl AccountApi for AccountApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = orig_client_order_id {
-            payload.insert("orig_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("origClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_list_id {
-            payload.insert("order_list_id".to_string(), serde_json::json!(value));
+            payload.insert("orderListId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -1210,18 +1197,19 @@ impl AccountApi for AccountApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = orig_client_order_id {
-            payload.insert("orig_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("origClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 

--- a/src/spot/websocket_api/apis/auth_api.rs
+++ b/src/spot/websocket_api/apis/auth_api.rs
@@ -20,6 +20,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -79,9 +80,6 @@ pub struct SessionLogonParams {
 impl SessionLogonParams {
     /// Create a builder for [`session_logon`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SessionLogonParamsBuilder {
         SessionLogonParamsBuilder::default()
@@ -103,9 +101,6 @@ pub struct SessionLogoutParams {
 
 impl SessionLogoutParams {
     /// Create a builder for [`session_logout`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> SessionLogoutParamsBuilder {
@@ -129,9 +124,6 @@ pub struct SessionStatusParams {
 impl SessionStatusParams {
     /// Create a builder for [`session_status`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SessionStatusParamsBuilder {
         SessionStatusParamsBuilder::default()
@@ -151,7 +143,7 @@ impl AuthApi for AuthApiClient {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 

--- a/src/spot/websocket_api/apis/general_api.rs
+++ b/src/spot/websocket_api/apis/general_api.rs
@@ -20,6 +20,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -130,9 +131,6 @@ pub struct ExchangeInfoParams {
 impl ExchangeInfoParams {
     /// Create a builder for [`exchange_info`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> ExchangeInfoParamsBuilder {
         ExchangeInfoParamsBuilder::default()
@@ -155,9 +153,6 @@ pub struct PingParams {
 impl PingParams {
     /// Create a builder for [`ping`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> PingParamsBuilder {
         PingParamsBuilder::default()
@@ -179,9 +174,6 @@ pub struct TimeParams {
 
 impl TimeParams {
     /// Create a builder for [`time`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> TimeParamsBuilder {
@@ -218,10 +210,10 @@ impl GeneralApi for GeneralApiClient {
             payload.insert("permissions".to_string(), serde_json::json!(value));
         }
         if let Some(value) = show_permission_sets {
-            payload.insert("show_permission_sets".to_string(), serde_json::json!(value));
+            payload.insert("showPermissionSets".to_string(), serde_json::json!(value));
         }
         if let Some(value) = symbol_status {
-            payload.insert("symbol_status".to_string(), serde_json::json!(value));
+            payload.insert("symbolStatus".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 

--- a/src/spot/websocket_api/apis/market_api.rs
+++ b/src/spot/websocket_api/apis/market_api.rs
@@ -20,6 +20,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -720,9 +721,6 @@ pub struct TickerParams {
 impl TickerParams {
     /// Create a builder for [`ticker`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> TickerParamsBuilder {
         TickerParamsBuilder::default()
@@ -761,9 +759,6 @@ pub struct Ticker24hrParams {
 impl Ticker24hrParams {
     /// Create a builder for [`ticker24hr`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> Ticker24hrParamsBuilder {
         Ticker24hrParamsBuilder::default()
@@ -796,9 +791,6 @@ pub struct TickerBookParams {
 impl TickerBookParams {
     /// Create a builder for [`ticker_book`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> TickerBookParamsBuilder {
         TickerBookParamsBuilder::default()
@@ -830,9 +822,6 @@ pub struct TickerPriceParams {
 
 impl TickerPriceParams {
     /// Create a builder for [`ticker_price`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> TickerPriceParamsBuilder {
@@ -876,9 +865,6 @@ pub struct TickerTradingDayParams {
 
 impl TickerTradingDayParams {
     /// Create a builder for [`ticker_trading_day`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> TickerTradingDayParamsBuilder {
@@ -1091,6 +1077,7 @@ impl MarketApi for MarketApiClient {
         let AvgPriceParams { symbol, id } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
@@ -1117,6 +1104,7 @@ impl MarketApi for MarketApiClient {
         let DepthParams { symbol, id, limit } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
@@ -1154,19 +1142,21 @@ impl MarketApi for MarketApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert("interval".to_string(), serde_json::json!(interval));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = start_time {
-            payload.insert("start_time".to_string(), serde_json::json!(value));
+            payload.insert("startTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = end_time {
-            payload.insert("end_time".to_string(), serde_json::json!(value));
+            payload.insert("endTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = time_zone {
-            payload.insert("time_zone".to_string(), serde_json::json!(value));
+            payload.insert("timeZone".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit {
             payload.insert("limit".to_string(), serde_json::json!(value));
@@ -1209,10 +1199,10 @@ impl MarketApi for MarketApiClient {
             payload.insert("symbols".to_string(), serde_json::json!(value));
         }
         if let Some(value) = r#type {
-            payload.insert("r#type".to_string(), serde_json::json!(value));
+            payload.insert("type".to_string(), serde_json::json!(value));
         }
         if let Some(value) = window_size {
-            payload.insert("window_size".to_string(), serde_json::json!(value));
+            payload.insert("windowSize".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -1251,7 +1241,7 @@ impl MarketApi for MarketApiClient {
             payload.insert("symbols".to_string(), serde_json::json!(value));
         }
         if let Some(value) = r#type {
-            payload.insert("r#type".to_string(), serde_json::json!(value));
+            payload.insert("type".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -1362,10 +1352,10 @@ impl MarketApi for MarketApiClient {
             payload.insert("symbols".to_string(), serde_json::json!(value));
         }
         if let Some(value) = time_zone {
-            payload.insert("time_zone".to_string(), serde_json::json!(value));
+            payload.insert("timeZone".to_string(), serde_json::json!(value));
         }
         if let Some(value) = r#type {
-            payload.insert("r#type".to_string(), serde_json::json!(value));
+            payload.insert("type".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -1396,18 +1386,19 @@ impl MarketApi for MarketApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = from_id {
-            payload.insert("from_id".to_string(), serde_json::json!(value));
+            payload.insert("fromId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = start_time {
-            payload.insert("start_time".to_string(), serde_json::json!(value));
+            payload.insert("startTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = end_time {
-            payload.insert("end_time".to_string(), serde_json::json!(value));
+            payload.insert("endTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit {
             payload.insert("limit".to_string(), serde_json::json!(value));
@@ -1440,12 +1431,13 @@ impl MarketApi for MarketApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = from_id {
-            payload.insert("from_id".to_string(), serde_json::json!(value));
+            payload.insert("fromId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit {
             payload.insert("limit".to_string(), serde_json::json!(value));
@@ -1472,6 +1464,7 @@ impl MarketApi for MarketApiClient {
         let TradesRecentParams { symbol, id, limit } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
@@ -1509,19 +1502,21 @@ impl MarketApi for MarketApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert("interval".to_string(), serde_json::json!(interval));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = start_time {
-            payload.insert("start_time".to_string(), serde_json::json!(value));
+            payload.insert("startTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = end_time {
-            payload.insert("end_time".to_string(), serde_json::json!(value));
+            payload.insert("endTime".to_string(), serde_json::json!(value));
         }
         if let Some(value) = time_zone {
-            payload.insert("time_zone".to_string(), serde_json::json!(value));
+            payload.insert("timeZone".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit {
             payload.insert("limit".to_string(), serde_json::json!(value));

--- a/src/spot/websocket_api/apis/trade_api.rs
+++ b/src/spot/websocket_api/apis/trade_api.rs
@@ -20,6 +20,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -2558,9 +2559,6 @@ pub struct OrderTestParams {
 impl OrderTestParams {
     /// Create a builder for [`order_test`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> OrderTestParamsBuilder {
         OrderTestParamsBuilder::default()
@@ -2701,9 +2699,6 @@ pub struct SorOrderTestParams {
 impl SorOrderTestParams {
     /// Create a builder for [`sor_order_test`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SorOrderTestParamsBuilder {
         SorOrderTestParamsBuilder::default()
@@ -2724,12 +2719,13 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -2762,22 +2758,24 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
-        payload.insert("new_qty".to_string(), serde_json::json!(new_qty));
+        let new_qty_value = Decimal::from_f32(new_qty).unwrap_or_default();
+        payload.insert("newQty".to_string(), serde_json::json!(new_qty_value));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = orig_client_order_id {
-            payload.insert("orig_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("origClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_client_order_id {
-            payload.insert("new_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("newClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -2809,24 +2807,25 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_id {
-            payload.insert("order_id".to_string(), serde_json::json!(value));
+            payload.insert("orderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = orig_client_order_id {
-            payload.insert("orig_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("origClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_client_order_id {
-            payload.insert("new_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("newClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = cancel_restrictions {
-            payload.insert("cancel_restrictions".to_string(), serde_json::json!(value));
+            payload.insert("cancelRestrictions".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -2874,81 +2873,91 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert(
-            "cancel_replace_mode".to_string(),
+            "cancelReplaceMode".to_string(),
             serde_json::json!(cancel_replace_mode),
         );
+
         payload.insert("side".to_string(), serde_json::json!(side));
-        payload.insert("r#type".to_string(), serde_json::json!(r#type));
+
+        payload.insert("type".to_string(), serde_json::json!(r#type));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = cancel_order_id {
-            payload.insert("cancel_order_id".to_string(), serde_json::json!(value));
+            payload.insert("cancelOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = cancel_orig_client_order_id {
             payload.insert(
-                "cancel_orig_client_order_id".to_string(),
+                "cancelOrigClientOrderId".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = cancel_new_client_order_id {
             payload.insert(
-                "cancel_new_client_order_id".to_string(),
+                "cancelNewClientOrderId".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = time_in_force {
-            payload.insert("time_in_force".to_string(), serde_json::json!(value));
+            payload.insert("timeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert("price".to_string(), serde_json::json!(value));
         }
         if let Some(value) = quantity {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert("quantity".to_string(), serde_json::json!(value));
         }
         if let Some(value) = quote_order_qty {
-            payload.insert("quote_order_qty".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("quoteOrderQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_client_order_id {
-            payload.insert("new_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("newClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_order_resp_type {
-            payload.insert("new_order_resp_type".to_string(), serde_json::json!(value));
+            payload.insert("newOrderRespType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_price {
-            payload.insert("stop_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("stopPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = trailing_delta {
-            payload.insert("trailing_delta".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("trailingDelta".to_string(), serde_json::json!(value));
         }
         if let Some(value) = iceberg_qty {
-            payload.insert("iceberg_qty".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("icebergQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = strategy_id {
-            payload.insert("strategy_id".to_string(), serde_json::json!(value));
+            payload.insert("strategyId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = strategy_type {
-            payload.insert("strategy_type".to_string(), serde_json::json!(value));
+            payload.insert("strategyType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = self_trade_prevention_mode {
             payload.insert(
-                "self_trade_prevention_mode".to_string(),
+                "selfTradePreventionMode".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = cancel_restrictions {
-            payload.insert("cancel_restrictions".to_string(), serde_json::json!(value));
+            payload.insert("cancelRestrictions".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_rate_limit_exceeded_mode {
             payload.insert(
-                "order_rate_limit_exceeded_mode".to_string(),
+                "orderRateLimitExceededMode".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -2979,21 +2988,22 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = order_list_id {
-            payload.insert("order_list_id".to_string(), serde_json::json!(value));
+            payload.insert("orderListId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = list_client_order_id {
-            payload.insert("list_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("listClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_client_order_id {
-            payload.insert("new_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("newClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -3039,69 +3049,71 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert("side".to_string(), serde_json::json!(side));
-        payload.insert("price".to_string(), serde_json::json!(price));
-        payload.insert("quantity".to_string(), serde_json::json!(quantity));
+        let price_value = Decimal::from_f32(price).unwrap_or_default();
+        payload.insert("price".to_string(), serde_json::json!(price_value));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        payload.insert("quantity".to_string(), serde_json::json!(quantity_value));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = list_client_order_id {
-            payload.insert("list_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("listClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit_client_order_id {
-            payload.insert(
-                "limit_client_order_id".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("limitClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit_iceberg_qty {
-            payload.insert("limit_iceberg_qty".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("limitIcebergQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit_strategy_id {
-            payload.insert("limit_strategy_id".to_string(), serde_json::json!(value));
+            payload.insert("limitStrategyId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = limit_strategy_type {
-            payload.insert("limit_strategy_type".to_string(), serde_json::json!(value));
+            payload.insert("limitStrategyType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_price {
-            payload.insert("stop_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("stopPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = trailing_delta {
-            payload.insert("trailing_delta".to_string(), serde_json::json!(value));
+            payload.insert("trailingDelta".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_client_order_id {
-            payload.insert("stop_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("stopClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_limit_price {
-            payload.insert("stop_limit_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("stopLimitPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_limit_time_in_force {
-            payload.insert(
-                "stop_limit_time_in_force".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("stopLimitTimeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_iceberg_qty {
-            payload.insert("stop_iceberg_qty".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("stopIcebergQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_strategy_id {
-            payload.insert("stop_strategy_id".to_string(), serde_json::json!(value));
+            payload.insert("stopStrategyId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_strategy_type {
-            payload.insert("stop_strategy_type".to_string(), serde_json::json!(value));
+            payload.insert("stopStrategyType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_order_resp_type {
-            payload.insert("new_order_resp_type".to_string(), serde_json::json!(value));
+            payload.insert("newOrderRespType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = self_trade_prevention_mode {
             payload.insert(
-                "self_trade_prevention_mode".to_string(),
+                "selfTradePreventionMode".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -3152,82 +3164,86 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert("side".to_string(), serde_json::json!(side));
-        payload.insert("quantity".to_string(), serde_json::json!(quantity));
-        payload.insert("above_type".to_string(), serde_json::json!(above_type));
-        payload.insert("below_type".to_string(), serde_json::json!(below_type));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        payload.insert("quantity".to_string(), serde_json::json!(quantity_value));
+
+        payload.insert("aboveType".to_string(), serde_json::json!(above_type));
+
+        payload.insert("belowType".to_string(), serde_json::json!(below_type));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = list_client_order_id {
-            payload.insert("list_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("listClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = above_client_order_id {
-            payload.insert(
-                "above_client_order_id".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("aboveClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = above_iceberg_qty {
-            payload.insert("above_iceberg_qty".to_string(), serde_json::json!(value));
+            payload.insert("aboveIcebergQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = above_price {
-            payload.insert("above_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("abovePrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = above_stop_price {
-            payload.insert("above_stop_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("aboveStopPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = above_trailing_delta {
-            payload.insert("above_trailing_delta".to_string(), serde_json::json!(value));
+            payload.insert("aboveTrailingDelta".to_string(), serde_json::json!(value));
         }
         if let Some(value) = above_time_in_force {
-            payload.insert("above_time_in_force".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("aboveTimeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = above_strategy_id {
-            payload.insert("above_strategy_id".to_string(), serde_json::json!(value));
+            payload.insert("aboveStrategyId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = above_strategy_type {
-            payload.insert("above_strategy_type".to_string(), serde_json::json!(value));
+            payload.insert("aboveStrategyType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = below_client_order_id {
-            payload.insert(
-                "below_client_order_id".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("belowClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = below_iceberg_qty {
-            payload.insert("below_iceberg_qty".to_string(), serde_json::json!(value));
+            payload.insert("belowIcebergQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = below_price {
-            payload.insert("below_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("belowPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = below_stop_price {
-            payload.insert("below_stop_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("belowStopPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = below_trailing_delta {
-            payload.insert("below_trailing_delta".to_string(), serde_json::json!(value));
+            payload.insert("belowTrailingDelta".to_string(), serde_json::json!(value));
         }
         if let Some(value) = below_time_in_force {
-            payload.insert("below_time_in_force".to_string(), serde_json::json!(value));
+            payload.insert("belowTimeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = below_strategy_id {
-            payload.insert("below_strategy_id".to_string(), serde_json::json!(value));
+            payload.insert("belowStrategyId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = below_strategy_type {
-            payload.insert("below_strategy_type".to_string(), serde_json::json!(value));
+            payload.insert("belowStrategyType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_order_resp_type {
-            payload.insert("new_order_resp_type".to_string(), serde_json::json!(value));
+            payload.insert("newOrderRespType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = self_trade_prevention_mode {
             payload.insert(
-                "self_trade_prevention_mode".to_string(),
+                "selfTradePreventionMode".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -3278,100 +3294,92 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
-        payload.insert("working_type".to_string(), serde_json::json!(working_type));
-        payload.insert("working_side".to_string(), serde_json::json!(working_side));
+
+        payload.insert("workingType".to_string(), serde_json::json!(working_type));
+
+        payload.insert("workingSide".to_string(), serde_json::json!(working_side));
+        let working_price_value = Decimal::from_f32(working_price).unwrap_or_default();
         payload.insert(
-            "working_price".to_string(),
-            serde_json::json!(working_price),
+            "workingPrice".to_string(),
+            serde_json::json!(working_price_value),
         );
+        let working_quantity_value = Decimal::from_f32(working_quantity).unwrap_or_default();
         payload.insert(
-            "working_quantity".to_string(),
-            serde_json::json!(working_quantity),
+            "workingQuantity".to_string(),
+            serde_json::json!(working_quantity_value),
         );
-        payload.insert("pending_type".to_string(), serde_json::json!(pending_type));
-        payload.insert("pending_side".to_string(), serde_json::json!(pending_side));
+
+        payload.insert("pendingType".to_string(), serde_json::json!(pending_type));
+
+        payload.insert("pendingSide".to_string(), serde_json::json!(pending_side));
+        let pending_quantity_value = Decimal::from_f32(pending_quantity).unwrap_or_default();
         payload.insert(
-            "pending_quantity".to_string(),
-            serde_json::json!(pending_quantity),
+            "pendingQuantity".to_string(),
+            serde_json::json!(pending_quantity_value),
         );
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = list_client_order_id {
-            payload.insert("list_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("listClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_order_resp_type {
-            payload.insert("new_order_resp_type".to_string(), serde_json::json!(value));
+            payload.insert("newOrderRespType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = self_trade_prevention_mode {
             payload.insert(
-                "self_trade_prevention_mode".to_string(),
+                "selfTradePreventionMode".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = working_client_order_id {
-            payload.insert(
-                "working_client_order_id".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("workingClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = working_iceberg_qty {
-            payload.insert("working_iceberg_qty".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("workingIcebergQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = working_time_in_force {
-            payload.insert(
-                "working_time_in_force".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("workingTimeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = working_strategy_id {
-            payload.insert("working_strategy_id".to_string(), serde_json::json!(value));
+            payload.insert("workingStrategyId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = working_strategy_type {
-            payload.insert(
-                "working_strategy_type".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("workingStrategyType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_client_order_id {
-            payload.insert(
-                "pending_client_order_id".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("pendingClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_price {
-            payload.insert("pending_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("pendingPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_stop_price {
-            payload.insert("pending_stop_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("pendingStopPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_trailing_delta {
-            payload.insert(
-                "pending_trailing_delta".to_string(),
-                serde_json::json!(value),
-            );
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("pendingTrailingDelta".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_iceberg_qty {
-            payload.insert("pending_iceberg_qty".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("pendingIcebergQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_time_in_force {
-            payload.insert(
-                "pending_time_in_force".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("pendingTimeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_strategy_id {
-            payload.insert("pending_strategy_id".to_string(), serde_json::json!(value));
+            payload.insert("pendingStrategyId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_strategy_type {
-            payload.insert(
-                "pending_strategy_type".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("pendingStrategyType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -3431,160 +3439,168 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
-        payload.insert("working_type".to_string(), serde_json::json!(working_type));
-        payload.insert("working_side".to_string(), serde_json::json!(working_side));
+
+        payload.insert("workingType".to_string(), serde_json::json!(working_type));
+
+        payload.insert("workingSide".to_string(), serde_json::json!(working_side));
+        let working_price_value = Decimal::from_f32(working_price).unwrap_or_default();
         payload.insert(
-            "working_price".to_string(),
-            serde_json::json!(working_price),
+            "workingPrice".to_string(),
+            serde_json::json!(working_price_value),
         );
+        let working_quantity_value = Decimal::from_f32(working_quantity).unwrap_or_default();
         payload.insert(
-            "working_quantity".to_string(),
-            serde_json::json!(working_quantity),
+            "workingQuantity".to_string(),
+            serde_json::json!(working_quantity_value),
         );
-        payload.insert("pending_side".to_string(), serde_json::json!(pending_side));
+
+        payload.insert("pendingSide".to_string(), serde_json::json!(pending_side));
+        let pending_quantity_value = Decimal::from_f32(pending_quantity).unwrap_or_default();
         payload.insert(
-            "pending_quantity".to_string(),
-            serde_json::json!(pending_quantity),
+            "pendingQuantity".to_string(),
+            serde_json::json!(pending_quantity_value),
         );
+
         payload.insert(
-            "pending_above_type".to_string(),
+            "pendingAboveType".to_string(),
             serde_json::json!(pending_above_type),
         );
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = list_client_order_id {
-            payload.insert("list_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("listClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_order_resp_type {
-            payload.insert("new_order_resp_type".to_string(), serde_json::json!(value));
+            payload.insert("newOrderRespType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = self_trade_prevention_mode {
             payload.insert(
-                "self_trade_prevention_mode".to_string(),
+                "selfTradePreventionMode".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = working_client_order_id {
-            payload.insert(
-                "working_client_order_id".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("workingClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = working_iceberg_qty {
-            payload.insert("working_iceberg_qty".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("workingIcebergQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = working_time_in_force {
-            payload.insert(
-                "working_time_in_force".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("workingTimeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = working_strategy_id {
-            payload.insert("working_strategy_id".to_string(), serde_json::json!(value));
+            payload.insert("workingStrategyId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = working_strategy_type {
-            payload.insert(
-                "working_strategy_type".to_string(),
-                serde_json::json!(value),
-            );
+            payload.insert("workingStrategyType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_above_client_order_id {
             payload.insert(
-                "pending_above_client_order_id".to_string(),
+                "pendingAboveClientOrderId".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_above_price {
-            payload.insert("pending_above_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("pendingAbovePrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_above_stop_price {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert(
-                "pending_above_stop_price".to_string(),
+                "pendingAboveStopPrice".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_above_trailing_delta {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert(
-                "pending_above_trailing_delta".to_string(),
+                "pendingAboveTrailingDelta".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_above_iceberg_qty {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert(
-                "pending_above_iceberg_qty".to_string(),
+                "pendingAboveIcebergQty".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_above_time_in_force {
             payload.insert(
-                "pending_above_time_in_force".to_string(),
+                "pendingAboveTimeInForce".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_above_strategy_id {
             payload.insert(
-                "pending_above_strategy_id".to_string(),
+                "pendingAboveStrategyId".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_above_strategy_type {
             payload.insert(
-                "pending_above_strategy_type".to_string(),
+                "pendingAboveStrategyType".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_below_type {
-            payload.insert("pending_below_type".to_string(), serde_json::json!(value));
+            payload.insert("pendingBelowType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_below_client_order_id {
             payload.insert(
-                "pending_below_client_order_id".to_string(),
+                "pendingBelowClientOrderId".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_below_price {
-            payload.insert("pending_below_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("pendingBelowPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = pending_below_stop_price {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert(
-                "pending_below_stop_price".to_string(),
+                "pendingBelowStopPrice".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_below_trailing_delta {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert(
-                "pending_below_trailing_delta".to_string(),
+                "pendingBelowTrailingDelta".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_below_iceberg_qty {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert(
-                "pending_below_iceberg_qty".to_string(),
+                "pendingBelowIcebergQty".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_below_time_in_force {
             payload.insert(
-                "pending_below_time_in_force".to_string(),
+                "pendingBelowTimeInForce".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_below_strategy_id {
             payload.insert(
-                "pending_below_strategy_id".to_string(),
+                "pendingBelowStrategyId".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = pending_below_strategy_type {
             payload.insert(
-                "pending_below_strategy_type".to_string(),
+                "pendingBelowStrategyType".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -3626,53 +3642,61 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert("side".to_string(), serde_json::json!(side));
-        payload.insert("r#type".to_string(), serde_json::json!(r#type));
+
+        payload.insert("type".to_string(), serde_json::json!(r#type));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = time_in_force {
-            payload.insert("time_in_force".to_string(), serde_json::json!(value));
+            payload.insert("timeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert("price".to_string(), serde_json::json!(value));
         }
         if let Some(value) = quantity {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert("quantity".to_string(), serde_json::json!(value));
         }
         if let Some(value) = quote_order_qty {
-            payload.insert("quote_order_qty".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("quoteOrderQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_client_order_id {
-            payload.insert("new_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("newClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_order_resp_type {
-            payload.insert("new_order_resp_type".to_string(), serde_json::json!(value));
+            payload.insert("newOrderRespType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = stop_price {
-            payload.insert("stop_price".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("stopPrice".to_string(), serde_json::json!(value));
         }
         if let Some(value) = trailing_delta {
-            payload.insert("trailing_delta".to_string(), serde_json::json!(value));
+            payload.insert("trailingDelta".to_string(), serde_json::json!(value));
         }
         if let Some(value) = iceberg_qty {
-            payload.insert("iceberg_qty".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("icebergQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = strategy_id {
-            payload.insert("strategy_id".to_string(), serde_json::json!(value));
+            payload.insert("strategyId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = strategy_type {
-            payload.insert("strategy_type".to_string(), serde_json::json!(value));
+            payload.insert("strategyType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = self_trade_prevention_mode {
             payload.insert(
-                "self_trade_prevention_mode".to_string(),
+                "selfTradePreventionMode".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -3704,7 +3728,7 @@ impl TradeApi for TradeApiClient {
         }
         if let Some(value) = compute_commission_rates {
             payload.insert(
-                "compute_commission_rates".to_string(),
+                "computeCommissionRates".to_string(),
                 serde_json::json!(value),
             );
         }
@@ -3745,42 +3769,48 @@ impl TradeApi for TradeApiClient {
         } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
+
         payload.insert("symbol".to_string(), serde_json::json!(symbol));
+
         payload.insert("side".to_string(), serde_json::json!(side));
-        payload.insert("r#type".to_string(), serde_json::json!(r#type));
-        payload.insert("quantity".to_string(), serde_json::json!(quantity));
+
+        payload.insert("type".to_string(), serde_json::json!(r#type));
+        let quantity_value = Decimal::from_f32(quantity).unwrap_or_default();
+        payload.insert("quantity".to_string(), serde_json::json!(quantity_value));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
         if let Some(value) = time_in_force {
-            payload.insert("time_in_force".to_string(), serde_json::json!(value));
+            payload.insert("timeInForce".to_string(), serde_json::json!(value));
         }
         if let Some(value) = price {
+            let value = Decimal::from_f32(value).unwrap_or_default();
             payload.insert("price".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_client_order_id {
-            payload.insert("new_client_order_id".to_string(), serde_json::json!(value));
+            payload.insert("newClientOrderId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = new_order_resp_type {
-            payload.insert("new_order_resp_type".to_string(), serde_json::json!(value));
+            payload.insert("newOrderRespType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = iceberg_qty {
-            payload.insert("iceberg_qty".to_string(), serde_json::json!(value));
+            let value = Decimal::from_f32(value).unwrap_or_default();
+            payload.insert("icebergQty".to_string(), serde_json::json!(value));
         }
         if let Some(value) = strategy_id {
-            payload.insert("strategy_id".to_string(), serde_json::json!(value));
+            payload.insert("strategyId".to_string(), serde_json::json!(value));
         }
         if let Some(value) = strategy_type {
-            payload.insert("strategy_type".to_string(), serde_json::json!(value));
+            payload.insert("strategyType".to_string(), serde_json::json!(value));
         }
         if let Some(value) = self_trade_prevention_mode {
             payload.insert(
-                "self_trade_prevention_mode".to_string(),
+                "selfTradePreventionMode".to_string(),
                 serde_json::json!(value),
             );
         }
         if let Some(value) = recv_window {
-            payload.insert("recv_window".to_string(), serde_json::json!(value));
+            payload.insert("recvWindow".to_string(), serde_json::json!(value));
         }
         let payload = remove_empty_value(payload);
 
@@ -3812,7 +3842,7 @@ impl TradeApi for TradeApiClient {
         }
         if let Some(value) = compute_commission_rates {
             payload.insert(
-                "compute_commission_rates".to_string(),
+                "computeCommissionRates".to_string(),
                 serde_json::json!(value),
             );
         }

--- a/src/spot/websocket_api/apis/user_data_stream_api.rs
+++ b/src/spot/websocket_api/apis/user_data_stream_api.rs
@@ -20,6 +20,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use derive_builder::Builder;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc};
@@ -114,9 +115,6 @@ pub struct UserDataStreamStartParams {
 impl UserDataStreamStartParams {
     /// Create a builder for [`user_data_stream_start`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> UserDataStreamStartParamsBuilder {
         UserDataStreamStartParamsBuilder::default()
@@ -171,9 +169,6 @@ pub struct UserDataStreamSubscribeParams {
 impl UserDataStreamSubscribeParams {
     /// Create a builder for [`user_data_stream_subscribe`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> UserDataStreamSubscribeParamsBuilder {
         UserDataStreamSubscribeParamsBuilder::default()
@@ -196,9 +191,6 @@ pub struct UserDataStreamUnsubscribeParams {
 impl UserDataStreamUnsubscribeParams {
     /// Create a builder for [`user_data_stream_unsubscribe`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> UserDataStreamUnsubscribeParamsBuilder {
         UserDataStreamUnsubscribeParamsBuilder::default()
@@ -214,7 +206,8 @@ impl UserDataStreamApi for UserDataStreamApiClient {
         let UserDataStreamPingParams { listen_key, id } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
-        payload.insert("listen_key".to_string(), serde_json::json!(listen_key));
+
+        payload.insert("listenKey".to_string(), serde_json::json!(listen_key));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }
@@ -265,7 +258,8 @@ impl UserDataStreamApi for UserDataStreamApiClient {
         let UserDataStreamStopParams { listen_key, id } = params;
 
         let mut payload: BTreeMap<String, Value> = BTreeMap::new();
-        payload.insert("listen_key".to_string(), serde_json::json!(listen_key));
+
+        payload.insert("listenKey".to_string(), serde_json::json!(listen_key));
         if let Some(value) = id {
             payload.insert("id".to_string(), serde_json::json!(value));
         }

--- a/src/spot/websocket_streams/apis/web_socket_streams_api.rs
+++ b/src/spot/websocket_streams/apis/web_socket_streams_api.rs
@@ -372,9 +372,6 @@ pub struct AllMiniTickerParams {
 impl AllMiniTickerParams {
     /// Create a builder for [`all_mini_ticker`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AllMiniTickerParamsBuilder {
         AllMiniTickerParamsBuilder::default()
@@ -396,9 +393,6 @@ pub struct AllTickerParams {
 
 impl AllTickerParams {
     /// Create a builder for [`all_ticker`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AllTickerParamsBuilder {
@@ -804,7 +798,7 @@ impl WebSocketStreamsApi for WebSocketStreamsApiClient {
         let AllMarketRollingWindowTickerParams { window_size, id } = params;
 
         let pairs: &[(&str, Option<String>)] = &[
-            ("window_size", Some(window_size.as_str().to_string())),
+            ("windowSize", Some(window_size.as_str().to_string())),
             ("id", id.clone()),
         ];
 
@@ -946,7 +940,7 @@ impl WebSocketStreamsApi for WebSocketStreamsApiClient {
         let pairs: &[(&str, Option<String>)] = &[
             ("symbol", Some(symbol.clone())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -1074,7 +1068,7 @@ impl WebSocketStreamsApi for WebSocketStreamsApiClient {
             ("symbol", Some(symbol.clone())),
             ("levels", Some(levels.as_str().to_string())),
             ("id", id.clone()),
-            ("update_speed", update_speed.clone()),
+            ("updateSpeed", update_speed.clone()),
         ];
 
         let vars: HashMap<_, _> = pairs
@@ -1107,7 +1101,7 @@ impl WebSocketStreamsApi for WebSocketStreamsApiClient {
 
         let pairs: &[(&str, Option<String>)] = &[
             ("symbol", Some(symbol.clone())),
-            ("window_size", Some(window_size.as_str().to_string())),
+            ("windowSize", Some(window_size.as_str().to_string())),
             ("id", id.clone()),
         ];
 
@@ -1365,7 +1359,7 @@ mod tests {
             let AllMarketRollingWindowTickerParams { window_size, id } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("window_size", Some(window_size.as_str().to_string())),
+                ("windowSize", Some(window_size.as_str().to_string())),
                 ("id", id.clone()),
             ];
 
@@ -1402,7 +1396,7 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("window_size",
+                ("windowSize",
                         Some(window_size.as_str().to_string())
                 ),
                 ("id",
@@ -1452,7 +1446,7 @@ mod tests {
             } = params.clone();
 
             let pairs: &[(&str, Option<String>)] = &[
-                ("window_size",
+                ("windowSize",
                         Some(window_size.as_str().to_string())
                 ),
                 ("id",
@@ -2064,7 +2058,7 @@ mod tests {
             let pairs: &[(&str, Option<String>)] = &[
                 ("symbol", Some(symbol.clone())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -2107,7 +2101,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -2160,7 +2154,7 @@ mod tests {
                 ("id",
                         id.clone()
                 ),
-                ("update_speed",
+                ("updateSpeed",
                         update_speed.clone()
                 ),
             ];
@@ -2678,7 +2672,7 @@ mod tests {
                 ("symbol", Some(symbol.clone())),
                 ("levels", Some(levels.as_str().to_string())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -2729,7 +2723,7 @@ mod tests {
                 ("symbol", Some(symbol.clone())),
                 ("levels", Some(levels.as_str().to_string())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -2795,7 +2789,7 @@ mod tests {
                 ("symbol", Some(symbol.clone())),
                 ("levels", Some(levels.as_str().to_string())),
                 ("id", id.clone()),
-                ("update_speed", update_speed.clone()),
+                ("updateSpeed", update_speed.clone()),
             ];
 
             let vars: HashMap<_, _> = pairs
@@ -2866,7 +2860,7 @@ mod tests {
 
             let pairs: &[(&str, Option<String>)] = &[
                 ("symbol", Some(symbol.clone())),
-                ("window_size", Some(window_size.as_str().to_string())),
+                ("windowSize", Some(window_size.as_str().to_string())),
                 ("id", id.clone()),
             ];
 
@@ -2907,7 +2901,7 @@ mod tests {
                 ("symbol",
                         Some(symbol.clone())
                 ),
-                ("window_size",
+                ("windowSize",
                         Some(window_size.as_str().to_string())
                 ),
                 ("id",
@@ -2960,7 +2954,7 @@ mod tests {
                 ("symbol",
                         Some(symbol.clone())
                 ),
-                ("window_size",
+                ("windowSize",
                         Some(window_size.as_str().to_string())
                 ),
                 ("id",

--- a/src/staking/rest_api/apis/eth_staking_api.rs
+++ b/src/staking/rest_api/apis/eth_staking_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -105,9 +106,6 @@ pub struct EthStakingAccountParams {
 impl EthStakingAccountParams {
     /// Create a builder for [`eth_staking_account`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> EthStakingAccountParamsBuilder {
         EthStakingAccountParamsBuilder::default()
@@ -130,9 +128,6 @@ pub struct GetCurrentEthStakingQuotaParams {
 
 impl GetCurrentEthStakingQuotaParams {
     /// Create a builder for [`get_current_eth_staking_quota`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetCurrentEthStakingQuotaParamsBuilder {
@@ -179,9 +174,6 @@ pub struct GetEthRedemptionHistoryParams {
 impl GetEthRedemptionHistoryParams {
     /// Create a builder for [`get_eth_redemption_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetEthRedemptionHistoryParamsBuilder {
         GetEthRedemptionHistoryParamsBuilder::default()
@@ -226,9 +218,6 @@ pub struct GetEthStakingHistoryParams {
 
 impl GetEthStakingHistoryParams {
     /// Create a builder for [`get_eth_staking_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetEthStakingHistoryParamsBuilder {
@@ -275,9 +264,6 @@ pub struct GetWbethRateHistoryParams {
 impl GetWbethRateHistoryParams {
     /// Create a builder for [`get_wbeth_rate_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetWbethRateHistoryParamsBuilder {
         GetWbethRateHistoryParamsBuilder::default()
@@ -322,9 +308,6 @@ pub struct GetWbethRewardsHistoryParams {
 
 impl GetWbethRewardsHistoryParams {
     /// Create a builder for [`get_wbeth_rewards_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetWbethRewardsHistoryParamsBuilder {
@@ -371,9 +354,6 @@ pub struct GetWbethUnwrapHistoryParams {
 impl GetWbethUnwrapHistoryParams {
     /// Create a builder for [`get_wbeth_unwrap_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetWbethUnwrapHistoryParamsBuilder {
         GetWbethUnwrapHistoryParamsBuilder::default()
@@ -418,9 +398,6 @@ pub struct GetWbethWrapHistoryParams {
 
 impl GetWbethWrapHistoryParams {
     /// Create a builder for [`get_wbeth_wrap_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetWbethWrapHistoryParamsBuilder {
@@ -540,7 +517,7 @@ impl EthStakingApi for EthStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::EthStakingAccountResponse>(
@@ -567,7 +544,7 @@ impl EthStakingApi for EthStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetCurrentEthStakingQuotaResponse>(
@@ -600,11 +577,11 @@ impl EthStakingApi for EthStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -616,7 +593,7 @@ impl EthStakingApi for EthStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetEthRedemptionHistoryResponse>(
@@ -649,11 +626,11 @@ impl EthStakingApi for EthStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -665,7 +642,7 @@ impl EthStakingApi for EthStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetEthStakingHistoryResponse>(
@@ -698,11 +675,11 @@ impl EthStakingApi for EthStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -714,7 +691,7 @@ impl EthStakingApi for EthStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetWbethRateHistoryResponse>(
@@ -747,11 +724,11 @@ impl EthStakingApi for EthStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -763,7 +740,7 @@ impl EthStakingApi for EthStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetWbethRewardsHistoryResponse>(
@@ -796,11 +773,11 @@ impl EthStakingApi for EthStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -812,7 +789,7 @@ impl EthStakingApi for EthStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetWbethUnwrapHistoryResponse>(
@@ -845,11 +822,11 @@ impl EthStakingApi for EthStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -861,7 +838,7 @@ impl EthStakingApi for EthStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetWbethWrapHistoryResponse>(
@@ -891,14 +868,15 @@ impl EthStakingApi for EthStakingApiClient {
 
         let mut query_params = BTreeMap::new();
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = asset {
             query_params.insert("asset".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::RedeemEthResponse>(
@@ -927,10 +905,11 @@ impl EthStakingApi for EthStakingApiClient {
 
         let mut query_params = BTreeMap::new();
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SubscribeEthStakingResponse>(
@@ -959,10 +938,11 @@ impl EthStakingApi for EthStakingApiClient {
 
         let mut query_params = BTreeMap::new();
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::WrapBethResponse>(

--- a/src/staking/rest_api/apis/sol_staking_api.rs
+++ b/src/staking/rest_api/apis/sol_staking_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -105,9 +106,6 @@ pub struct ClaimBoostRewardsParams {
 impl ClaimBoostRewardsParams {
     /// Create a builder for [`claim_boost_rewards`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> ClaimBoostRewardsParamsBuilder {
         ClaimBoostRewardsParamsBuilder::default()
@@ -153,9 +151,6 @@ pub struct GetBnsolRateHistoryParams {
 impl GetBnsolRateHistoryParams {
     /// Create a builder for [`get_bnsol_rate_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetBnsolRateHistoryParamsBuilder {
         GetBnsolRateHistoryParamsBuilder::default()
@@ -200,9 +195,6 @@ pub struct GetBnsolRewardsHistoryParams {
 
 impl GetBnsolRewardsHistoryParams {
     /// Create a builder for [`get_bnsol_rewards_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetBnsolRewardsHistoryParamsBuilder {
@@ -303,9 +295,6 @@ pub struct GetSolRedemptionHistoryParams {
 impl GetSolRedemptionHistoryParams {
     /// Create a builder for [`get_sol_redemption_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetSolRedemptionHistoryParamsBuilder {
         GetSolRedemptionHistoryParamsBuilder::default()
@@ -351,9 +340,6 @@ pub struct GetSolStakingHistoryParams {
 impl GetSolStakingHistoryParams {
     /// Create a builder for [`get_sol_staking_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetSolStakingHistoryParamsBuilder {
         GetSolStakingHistoryParamsBuilder::default()
@@ -377,9 +363,6 @@ pub struct GetSolStakingQuotaDetailsParams {
 impl GetSolStakingQuotaDetailsParams {
     /// Create a builder for [`get_sol_staking_quota_details`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetSolStakingQuotaDetailsParamsBuilder {
         GetSolStakingQuotaDetailsParamsBuilder::default()
@@ -402,9 +385,6 @@ pub struct GetUnclaimedRewardsParams {
 
 impl GetUnclaimedRewardsParams {
     /// Create a builder for [`get_unclaimed_rewards`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetUnclaimedRewardsParamsBuilder {
@@ -461,9 +441,6 @@ pub struct SolStakingAccountParams {
 impl SolStakingAccountParams {
     /// Create a builder for [`sol_staking_account`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> SolStakingAccountParamsBuilder {
         SolStakingAccountParamsBuilder::default()
@@ -513,7 +490,7 @@ impl SolStakingApi for SolStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ClaimBoostRewardsResponse>(
@@ -546,11 +523,11 @@ impl SolStakingApi for SolStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -562,7 +539,7 @@ impl SolStakingApi for SolStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetBnsolRateHistoryResponse>(
@@ -595,11 +572,11 @@ impl SolStakingApi for SolStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -611,7 +588,7 @@ impl SolStakingApi for SolStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetBnsolRewardsHistoryResponse>(
@@ -647,11 +624,11 @@ impl SolStakingApi for SolStakingApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -663,7 +640,7 @@ impl SolStakingApi for SolStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetBoostRewardsHistoryResponse>(
@@ -696,11 +673,11 @@ impl SolStakingApi for SolStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -712,7 +689,7 @@ impl SolStakingApi for SolStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSolRedemptionHistoryResponse>(
@@ -745,11 +722,11 @@ impl SolStakingApi for SolStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -761,7 +738,7 @@ impl SolStakingApi for SolStakingApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSolStakingHistoryResponse>(
@@ -788,7 +765,7 @@ impl SolStakingApi for SolStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSolStakingQuotaDetailsResponse>(
@@ -815,7 +792,7 @@ impl SolStakingApi for SolStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetUnclaimedRewardsResponseInner>>(
@@ -844,10 +821,11 @@ impl SolStakingApi for SolStakingApiClient {
 
         let mut query_params = BTreeMap::new();
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::RedeemSolResponse>(
@@ -874,7 +852,7 @@ impl SolStakingApi for SolStakingApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SolStakingAccountResponse>(
@@ -903,10 +881,11 @@ impl SolStakingApi for SolStakingApiClient {
 
         let mut query_params = BTreeMap::new();
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SubscribeSolStakingResponse>(

--- a/src/sub_account/rest_api/apis/account_management_api.rs
+++ b/src/sub_account/rest_api/apis/account_management_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -275,9 +276,6 @@ pub struct GetSubAccountsStatusOnMarginOrFuturesParams {
 impl GetSubAccountsStatusOnMarginOrFuturesParams {
     /// Create a builder for [`get_sub_accounts_status_on_margin_or_futures`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetSubAccountsStatusOnMarginOrFuturesParamsBuilder {
         GetSubAccountsStatusOnMarginOrFuturesParamsBuilder::default()
@@ -320,9 +318,6 @@ pub struct QuerySubAccountListParams {
 
 impl QuerySubAccountListParams {
     /// Create a builder for [`query_sub_account_list`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QuerySubAccountListParamsBuilder {
@@ -378,7 +373,7 @@ impl AccountManagementApi for AccountManagementApiClient {
         query_params.insert("subAccountString".to_string(), json!(sub_account_string));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CreateAVirtualSubAccountResponse>(
@@ -407,7 +402,7 @@ impl AccountManagementApi for AccountManagementApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::EnableFuturesForSubAccountResponse>(
@@ -436,7 +431,7 @@ impl AccountManagementApi for AccountManagementApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::EnableOptionsForSubAccountResponse>(
@@ -469,7 +464,7 @@ impl AccountManagementApi for AccountManagementApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<
@@ -506,7 +501,7 @@ impl AccountManagementApi for AccountManagementApiClient {
         query_params.insert("futuresType".to_string(), json!(futures_type));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetFuturesPositionRiskOfSubAccountV2Response>(
@@ -539,7 +534,7 @@ impl AccountManagementApi for AccountManagementApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetSubAccountsStatusOnMarginOrFuturesResponseInner>>(
@@ -576,7 +571,7 @@ impl AccountManagementApi for AccountManagementApiClient {
         }
 
         if let Some(rw) = is_freeze {
-            query_params.insert("is_freeze".to_string(), json!(rw));
+            query_params.insert("isFreeze".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -588,7 +583,7 @@ impl AccountManagementApi for AccountManagementApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QuerySubAccountListResponse>(
@@ -617,7 +612,7 @@ impl AccountManagementApi for AccountManagementApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QuerySubAccountTransactionStatisticsResponse>(

--- a/src/sub_account/rest_api/apis/api_management_api.rs
+++ b/src/sub_account/rest_api/apis/api_management_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -232,11 +233,11 @@ impl ApiManagementApi for ApiManagementApiClient {
         query_params.insert("status".to_string(), json!(status));
 
         if let Some(rw) = ip_address {
-            query_params.insert("ip_address".to_string(), json!(rw));
+            query_params.insert("ipAddress".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AddIpRestrictionForSubAccountApiKeyResponse>(
@@ -274,7 +275,7 @@ impl ApiManagementApi for ApiManagementApiClient {
         query_params.insert("ipAddress".to_string(), json!(ip_address));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::DeleteIpListForASubAccountApiKeyResponse>(
@@ -309,7 +310,7 @@ impl ApiManagementApi for ApiManagementApiClient {
         query_params.insert("subAccountApiKey".to_string(), json!(sub_account_api_key));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetIpRestrictionForASubAccountApiKeyResponse>(

--- a/src/sub_account/rest_api/apis/asset_management_api.rs
+++ b/src/sub_account/rest_api/apis/asset_management_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -511,9 +512,6 @@ pub struct GetSummaryOfSubAccountsFuturesAccountParams {
 impl GetSummaryOfSubAccountsFuturesAccountParams {
     /// Create a builder for [`get_summary_of_sub_accounts_futures_account`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetSummaryOfSubAccountsFuturesAccountParamsBuilder {
         GetSummaryOfSubAccountsFuturesAccountParamsBuilder::default()
@@ -578,9 +576,6 @@ pub struct GetSummaryOfSubAccountsMarginAccountParams {
 
 impl GetSummaryOfSubAccountsMarginAccountParams {
     /// Create a builder for [`get_summary_of_sub_accounts_margin_account`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetSummaryOfSubAccountsMarginAccountParamsBuilder {
@@ -890,9 +885,6 @@ pub struct QuerySubAccountSpotAssetTransferHistoryParams {
 impl QuerySubAccountSpotAssetTransferHistoryParams {
     /// Create a builder for [`query_sub_account_spot_asset_transfer_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QuerySubAccountSpotAssetTransferHistoryParamsBuilder {
         QuerySubAccountSpotAssetTransferHistoryParamsBuilder::default()
@@ -930,9 +922,6 @@ pub struct QuerySubAccountSpotAssetsSummaryParams {
 
 impl QuerySubAccountSpotAssetsSummaryParams {
     /// Create a builder for [`query_sub_account_spot_assets_summary`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QuerySubAccountSpotAssetsSummaryParamsBuilder {
@@ -996,9 +985,6 @@ pub struct QueryUniversalTransferHistoryParams {
 
 impl QueryUniversalTransferHistoryParams {
     /// Create a builder for [`query_universal_transfer_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryUniversalTransferHistoryParamsBuilder {
@@ -1125,9 +1111,6 @@ pub struct SubAccountTransferHistoryParams {
 
 impl SubAccountTransferHistoryParams {
     /// Create a builder for [`sub_account_transfer_history`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> SubAccountTransferHistoryParamsBuilder {
@@ -1335,12 +1318,13 @@ impl AssetManagementApi for AssetManagementApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::FuturesTransferForSubAccountResponse>(
@@ -1369,7 +1353,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDetailOnSubAccountsFuturesAccountResponse>(
@@ -1405,7 +1389,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         query_params.insert("futuresType".to_string(), json!(futures_type));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDetailOnSubAccountsFuturesAccountV2Response>(
@@ -1434,7 +1418,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetDetailOnSubAccountsMarginAccountResponse>(
@@ -1474,15 +1458,15 @@ impl AssetManagementApi for AssetManagementApiClient {
         query_params.insert("row".to_string(), json!(row));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetMovePositionHistoryForSubAccountResponse>(
@@ -1523,11 +1507,12 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = amount {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("amount".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSubAccountDepositAddressResponse>(
@@ -1575,11 +1560,11 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -1591,11 +1576,11 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         if let Some(rw) = tx_id {
-            query_params.insert("tx_id".to_string(), json!(rw));
+            query_params.insert("txId".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetSubAccountDepositHistoryResponseInner>>(
@@ -1623,7 +1608,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSummaryOfSubAccountsFuturesAccountResponse>(
@@ -1666,7 +1651,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSummaryOfSubAccountsFuturesAccountV2Response>(
@@ -1693,7 +1678,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetSummaryOfSubAccountsMarginAccountResponse>(
@@ -1729,12 +1714,13 @@ impl AssetManagementApi for AssetManagementApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MarginTransferForSubAccountResponse>(
@@ -1775,7 +1761,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         query_params.insert("orderArgs".to_string(), json!(order_args));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::MovePositionForSubAccountResponse>(
@@ -1804,7 +1790,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QuerySubAccountAssetsResponse>(
@@ -1833,7 +1819,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QuerySubAccountAssetsAssetManagementResponse>(
@@ -1873,11 +1859,11 @@ impl AssetManagementApi for AssetManagementApiClient {
         query_params.insert("futuresType".to_string(), json!(futures_type));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -1889,7 +1875,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QuerySubAccountFuturesAssetTransferHistoryResponse>(
@@ -1926,19 +1912,19 @@ impl AssetManagementApi for AssetManagementApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = from_email {
-            query_params.insert("from_email".to_string(), json!(rw));
+            query_params.insert("fromEmail".to_string(), json!(rw));
         }
 
         if let Some(rw) = to_email {
-            query_params.insert("to_email".to_string(), json!(rw));
+            query_params.insert("toEmail".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -1950,7 +1936,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QuerySubAccountSpotAssetTransferHistoryResponseInner>>(
@@ -1994,7 +1980,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QuerySubAccountSpotAssetsSummaryResponse>(
@@ -2030,23 +2016,23 @@ impl AssetManagementApi for AssetManagementApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = from_email {
-            query_params.insert("from_email".to_string(), json!(rw));
+            query_params.insert("fromEmail".to_string(), json!(rw));
         }
 
         if let Some(rw) = to_email {
-            query_params.insert("to_email".to_string(), json!(rw));
+            query_params.insert("toEmail".to_string(), json!(rw));
         }
 
         if let Some(rw) = client_tran_id {
-            query_params.insert("client_tran_id".to_string(), json!(rw));
+            query_params.insert("clientTranId".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = page {
@@ -2058,7 +2044,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryUniversalTransferHistoryResponse>(
@@ -2099,10 +2085,11 @@ impl AssetManagementApi for AssetManagementApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::SubAccountFuturesAssetTransferResponse>(
@@ -2141,15 +2128,15 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = r#type {
-            query_params.insert("r#type".to_string(), json!(rw));
+            query_params.insert("type".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -2157,11 +2144,11 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = return_fail_history {
-            query_params.insert("return_fail_history".to_string(), json!(rw));
+            query_params.insert("returnFailHistory".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::SubAccountTransferHistoryResponseInner>>(
@@ -2193,10 +2180,11 @@ impl AssetManagementApi for AssetManagementApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::TransferToMasterResponse>(
@@ -2231,10 +2219,11 @@ impl AssetManagementApi for AssetManagementApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::TransferToSubAccountOfSameMasterResponse>(
@@ -2276,18 +2265,19 @@ impl AssetManagementApi for AssetManagementApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = from_email {
-            query_params.insert("from_email".to_string(), json!(rw));
+            query_params.insert("fromEmail".to_string(), json!(rw));
         }
 
         if let Some(rw) = to_email {
-            query_params.insert("to_email".to_string(), json!(rw));
+            query_params.insert("toEmail".to_string(), json!(rw));
         }
 
         if let Some(rw) = client_tran_id {
-            query_params.insert("client_tran_id".to_string(), json!(rw));
+            query_params.insert("clientTranId".to_string(), json!(rw));
         }
 
         if let Some(rw) = symbol {
@@ -2295,7 +2285,7 @@ impl AssetManagementApi for AssetManagementApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::UniversalTransferResponse>(

--- a/src/sub_account/rest_api/apis/managed_sub_account_api.rs
+++ b/src/sub_account/rest_api/apis/managed_sub_account_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -294,9 +295,6 @@ pub struct QueryManagedSubAccountListParams {
 
 impl QueryManagedSubAccountListParams {
     /// Create a builder for [`query_managed_sub_account_list`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> QueryManagedSubAccountListParamsBuilder {
@@ -682,10 +680,11 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::DepositAssetsIntoTheManagedSubAccountResponse>(
@@ -726,11 +725,12 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
         }
 
         if let Some(rw) = amount {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("amount".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetManagedSubAccountDepositAddressResponse>(
@@ -760,7 +760,7 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryManagedSubAccountAssetDetailsResponseInner>>(
@@ -793,7 +793,7 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = account_type {
-            query_params.insert("account_type".to_string(), json!(rw));
+            query_params.insert("accountType".to_string(), json!(rw));
         }
 
         send_request::<models::QueryManagedSubAccountFuturesAssetDetailsResponse>(
@@ -837,7 +837,7 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryManagedSubAccountListResponse>(
@@ -870,7 +870,7 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
         query_params.insert("email".to_string(), json!(email));
 
         if let Some(rw) = account_type {
-            query_params.insert("account_type".to_string(), json!(rw));
+            query_params.insert("accountType".to_string(), json!(rw));
         }
 
         send_request::<models::QueryManagedSubAccountMarginAssetDetailsResponse>(
@@ -908,11 +908,11 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -920,7 +920,7 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryManagedSubAccountSnapshotResponse>(
@@ -971,7 +971,7 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
         }
 
         if let Some(rw) = transfer_function_account_type {
-            query_params.insert("transfer_function_account_type".to_string(), json!(rw));
+            query_params.insert("transferFunctionAccountType".to_string(), json!(rw));
         }
 
         send_request::<models::QueryManagedSubAccountTransferLogMasterAccountInvestorResponse>(
@@ -1022,7 +1022,7 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
         }
 
         if let Some(rw) = transfer_function_account_type {
-            query_params.insert("transfer_function_account_type".to_string(), json!(rw));
+            query_params.insert("transferFunctionAccountType".to_string(), json!(rw));
         }
 
         send_request::<models::QueryManagedSubAccountTransferLogMasterAccountTradingResponse>(
@@ -1071,11 +1071,11 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
         }
 
         if let Some(rw) = transfer_function_account_type {
-            query_params.insert("transfer_function_account_type".to_string(), json!(rw));
+            query_params.insert("transferFunctionAccountType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryManagedSubAccountTransferLogSubAccountTradingResponse>(
@@ -1112,14 +1112,15 @@ impl ManagedSubAccountApi for ManagedSubAccountApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = transfer_date {
-            query_params.insert("transfer_date".to_string(), json!(rw));
+            query_params.insert("transferDate".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::WithdrawlAssetsFromTheManagedSubAccountResponse>(

--- a/src/vip_loan/rest_api/apis/market_data_api.rs
+++ b/src/vip_loan/rest_api/apis/market_data_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -112,9 +113,6 @@ pub struct GetCollateralAssetDataParams {
 impl GetCollateralAssetDataParams {
     /// Create a builder for [`get_collateral_asset_data`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetCollateralAssetDataParamsBuilder {
         GetCollateralAssetDataParamsBuilder::default()
@@ -149,9 +147,6 @@ pub struct GetLoanableAssetsDataParams {
 impl GetLoanableAssetsDataParams {
     /// Create a builder for [`get_loanable_assets_data`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetLoanableAssetsDataParamsBuilder {
         GetLoanableAssetsDataParamsBuilder::default()
@@ -174,7 +169,7 @@ impl MarketDataApi for MarketDataApiClient {
         query_params.insert("loanCoin".to_string(), json!(loan_coin));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetBorrowInterestRateResponseInner>>(
@@ -204,11 +199,11 @@ impl MarketDataApi for MarketDataApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetCollateralAssetDataResponse>(
@@ -239,15 +234,15 @@ impl MarketDataApi for MarketDataApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = vip_level {
-            query_params.insert("vip_level".to_string(), json!(rw));
+            query_params.insert("vipLevel".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetLoanableAssetsDataResponse>(

--- a/src/vip_loan/rest_api/apis/trade_api.rs
+++ b/src/vip_loan/rest_api/apis/trade_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -239,7 +240,8 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("loanCoin".to_string(), json!(loan_coin));
 
-        query_params.insert("loanAmount".to_string(), json!(loan_amount));
+        let loan_amount_value = Decimal::from_f32(loan_amount).unwrap_or_default();
+        query_params.insert("loanAmount".to_string(), json!(loan_amount_value));
 
         query_params.insert(
             "collateralAccountId".to_string(),
@@ -251,7 +253,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("isFlexibleRate".to_string(), json!(is_flexible_rate));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::VipLoanBorrowResponse>(
@@ -286,7 +288,7 @@ impl TradeApi for TradeApiClient {
         query_params.insert("loanTerm".to_string(), json!(loan_term));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::VipLoanRenewResponse>(
@@ -318,10 +320,11 @@ impl TradeApi for TradeApiClient {
 
         query_params.insert("orderId".to_string(), json!(order_id));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::VipLoanRepayResponse>(

--- a/src/vip_loan/rest_api/apis/user_information_api.rs
+++ b/src/vip_loan/rest_api/apis/user_information_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -85,9 +86,6 @@ pub struct CheckVipLoanCollateralAccountParams {
 impl CheckVipLoanCollateralAccountParams {
     /// Create a builder for [`check_vip_loan_collateral_account`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> CheckVipLoanCollateralAccountParamsBuilder {
         CheckVipLoanCollateralAccountParamsBuilder::default()
@@ -145,9 +143,6 @@ pub struct GetVipLoanOngoingOrdersParams {
 impl GetVipLoanOngoingOrdersParams {
     /// Create a builder for [`get_vip_loan_ongoing_orders`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetVipLoanOngoingOrdersParamsBuilder {
         GetVipLoanOngoingOrdersParamsBuilder::default()
@@ -181,9 +176,6 @@ pub struct QueryApplicationStatusParams {
 impl QueryApplicationStatusParams {
     /// Create a builder for [`query_application_status`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryApplicationStatusParamsBuilder {
         QueryApplicationStatusParamsBuilder::default()
@@ -205,15 +197,15 @@ impl UserInformationApi for UserInformationApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_account_id {
-            query_params.insert("collateral_account_id".to_string(), json!(rw));
+            query_params.insert("collateralAccountId".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::CheckVipLoanCollateralAccountResponse>(
@@ -248,19 +240,19 @@ impl UserInformationApi for UserInformationApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = order_id {
-            query_params.insert("order_id".to_string(), json!(rw));
+            query_params.insert("orderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_account_id {
-            query_params.insert("collateral_account_id".to_string(), json!(rw));
+            query_params.insert("collateralAccountId".to_string(), json!(rw));
         }
 
         if let Some(rw) = loan_coin {
-            query_params.insert("loan_coin".to_string(), json!(rw));
+            query_params.insert("loanCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = collateral_coin {
-            query_params.insert("collateral_coin".to_string(), json!(rw));
+            query_params.insert("collateralCoin".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -272,7 +264,7 @@ impl UserInformationApi for UserInformationApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetVipLoanOngoingOrdersResponse>(
@@ -311,7 +303,7 @@ impl UserInformationApi for UserInformationApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryApplicationStatusResponse>(

--- a/src/wallet/rest_api/apis/account_api.rs
+++ b/src/wallet/rest_api/apis/account_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -89,9 +90,6 @@ pub struct AccountApiTradingStatusParams {
 impl AccountApiTradingStatusParams {
     /// Create a builder for [`account_api_trading_status`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AccountApiTradingStatusParamsBuilder {
         AccountApiTradingStatusParamsBuilder::default()
@@ -115,9 +113,6 @@ pub struct AccountInfoParams {
 impl AccountInfoParams {
     /// Create a builder for [`account_info`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AccountInfoParamsBuilder {
         AccountInfoParamsBuilder::default()
@@ -140,9 +135,6 @@ pub struct AccountStatusParams {
 
 impl AccountStatusParams {
     /// Create a builder for [`account_status`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AccountStatusParamsBuilder {
@@ -217,9 +209,6 @@ pub struct DisableFastWithdrawSwitchParams {
 impl DisableFastWithdrawSwitchParams {
     /// Create a builder for [`disable_fast_withdraw_switch`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> DisableFastWithdrawSwitchParamsBuilder {
         DisableFastWithdrawSwitchParamsBuilder::default()
@@ -242,9 +231,6 @@ pub struct EnableFastWithdrawSwitchParams {
 
 impl EnableFastWithdrawSwitchParams {
     /// Create a builder for [`enable_fast_withdraw_switch`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> EnableFastWithdrawSwitchParamsBuilder {
@@ -269,9 +255,6 @@ pub struct GetApiKeyPermissionParams {
 impl GetApiKeyPermissionParams {
     /// Create a builder for [`get_api_key_permission`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetApiKeyPermissionParamsBuilder {
         GetApiKeyPermissionParamsBuilder::default()
@@ -289,7 +272,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AccountApiTradingStatusResponse>(
@@ -316,7 +299,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AccountInfoResponse>(
@@ -343,7 +326,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AccountStatusResponse>(
@@ -378,11 +361,11 @@ impl AccountApi for AccountApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -390,7 +373,7 @@ impl AccountApi for AccountApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::DailyAccountSnapshotResponse>(
@@ -417,7 +400,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Value>(
@@ -444,7 +427,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Value>(
@@ -471,7 +454,7 @@ impl AccountApi for AccountApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetApiKeyPermissionResponse>(

--- a/src/wallet/rest_api/apis/asset_api.rs
+++ b/src/wallet/rest_api/apis/asset_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -120,9 +121,6 @@ pub struct AssetDetailParams {
 impl AssetDetailParams {
     /// Create a builder for [`asset_detail`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> AssetDetailParamsBuilder {
         AssetDetailParamsBuilder::default()
@@ -167,9 +165,6 @@ pub struct AssetDividendRecordParams {
 
 impl AssetDividendRecordParams {
     /// Create a builder for [`asset_dividend_record`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AssetDividendRecordParamsBuilder {
@@ -244,9 +239,6 @@ pub struct DustlogParams {
 impl DustlogParams {
     /// Create a builder for [`dustlog`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> DustlogParamsBuilder {
         DustlogParamsBuilder::default()
@@ -280,9 +272,6 @@ pub struct FundingWalletParams {
 impl FundingWalletParams {
     /// Create a builder for [`funding_wallet`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> FundingWalletParamsBuilder {
         FundingWalletParamsBuilder::default()
@@ -310,9 +299,6 @@ pub struct GetAssetsThatCanBeConvertedIntoBnbParams {
 
 impl GetAssetsThatCanBeConvertedIntoBnbParams {
     /// Create a builder for [`get_assets_that_can_be_converted_into_bnb`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> GetAssetsThatCanBeConvertedIntoBnbParamsBuilder {
@@ -547,9 +533,6 @@ pub struct QueryUserWalletBalanceParams {
 impl QueryUserWalletBalanceParams {
     /// Create a builder for [`query_user_wallet_balance`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> QueryUserWalletBalanceParamsBuilder {
         QueryUserWalletBalanceParamsBuilder::default()
@@ -583,9 +566,6 @@ pub struct ToggleBnbBurnOnSpotTradeAndMarginInterestParams {
 impl ToggleBnbBurnOnSpotTradeAndMarginInterestParams {
     /// Create a builder for [`toggle_bnb_burn_on_spot_trade_and_margin_interest`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> ToggleBnbBurnOnSpotTradeAndMarginInterestParamsBuilder {
         ToggleBnbBurnOnSpotTradeAndMarginInterestParamsBuilder::default()
@@ -614,9 +594,6 @@ pub struct TradeFeeParams {
 
 impl TradeFeeParams {
     /// Create a builder for [`trade_fee`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> TradeFeeParamsBuilder {
@@ -650,9 +627,6 @@ pub struct UserAssetParams {
 
 impl UserAssetParams {
     /// Create a builder for [`user_asset`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> UserAssetParamsBuilder {
@@ -737,7 +711,7 @@ impl AssetApi for AssetApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AssetDetailResponse>(
@@ -774,11 +748,11 @@ impl AssetApi for AssetApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = limit {
@@ -786,7 +760,7 @@ impl AssetApi for AssetApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::AssetDividendRecordResponse>(
@@ -819,11 +793,11 @@ impl AssetApi for AssetApiClient {
         query_params.insert("asset".to_string(), json!(asset));
 
         if let Some(rw) = account_type {
-            query_params.insert("account_type".to_string(), json!(rw));
+            query_params.insert("accountType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::DustTransferResponse>(
@@ -854,15 +828,15 @@ impl AssetApi for AssetApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::DustlogResponse>(
@@ -897,11 +871,11 @@ impl AssetApi for AssetApiClient {
         }
 
         if let Some(rw) = need_btc_valuation {
-            query_params.insert("need_btc_valuation".to_string(), json!(rw));
+            query_params.insert("needBtcValuation".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::FundingWalletResponseInner>>(
@@ -931,11 +905,11 @@ impl AssetApi for AssetApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = account_type {
-            query_params.insert("account_type".to_string(), json!(rw));
+            query_params.insert("accountType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::GetAssetsThatCanBeConvertedIntoBnbResponse>(
@@ -975,11 +949,11 @@ impl AssetApi for AssetApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = tran_id {
-            query_params.insert("tran_id".to_string(), json!(rw));
+            query_params.insert("tranId".to_string(), json!(rw));
         }
 
         if let Some(rw) = client_tran_id {
-            query_params.insert("client_tran_id".to_string(), json!(rw));
+            query_params.insert("clientTranId".to_string(), json!(rw));
         }
 
         if let Some(rw) = asset {
@@ -1053,7 +1027,7 @@ impl AssetApi for AssetApiClient {
         query_params.insert("endTime".to_string(), json!(end_time));
 
         if let Some(rw) = r#type {
-            query_params.insert("r#type".to_string(), json!(rw));
+            query_params.insert("type".to_string(), json!(rw));
         }
 
         if let Some(rw) = asset {
@@ -1069,7 +1043,7 @@ impl AssetApi for AssetApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryUserDelegationHistoryResponse>(
@@ -1107,11 +1081,11 @@ impl AssetApi for AssetApiClient {
         query_params.insert("type".to_string(), json!(r#type));
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = current {
@@ -1123,15 +1097,15 @@ impl AssetApi for AssetApiClient {
         }
 
         if let Some(rw) = from_symbol {
-            query_params.insert("from_symbol".to_string(), json!(rw));
+            query_params.insert("fromSymbol".to_string(), json!(rw));
         }
 
         if let Some(rw) = to_symbol {
-            query_params.insert("to_symbol".to_string(), json!(rw));
+            query_params.insert("toSymbol".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::QueryUserUniversalTransferHistoryResponse>(
@@ -1161,11 +1135,11 @@ impl AssetApi for AssetApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = quote_asset {
-            query_params.insert("quote_asset".to_string(), json!(rw));
+            query_params.insert("quoteAsset".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::QueryUserWalletBalanceResponseInner>>(
@@ -1197,15 +1171,15 @@ impl AssetApi for AssetApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = spot_bnb_burn {
-            query_params.insert("spot_bnb_burn".to_string(), json!(rw));
+            query_params.insert("spotBNBBurn".to_string(), json!(rw));
         }
 
         if let Some(rw) = interest_bnb_burn {
-            query_params.insert("interest_bnb_burn".to_string(), json!(rw));
+            query_params.insert("interestBNBBurn".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::ToggleBnbBurnOnSpotTradeAndMarginInterestResponse>(
@@ -1239,7 +1213,7 @@ impl AssetApi for AssetApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::TradeFeeResponseInner>>(
@@ -1274,11 +1248,11 @@ impl AssetApi for AssetApiClient {
         }
 
         if let Some(rw) = need_btc_valuation {
-            query_params.insert("need_btc_valuation".to_string(), json!(rw));
+            query_params.insert("needBtcValuation".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::UserAssetResponseInner>>(
@@ -1315,18 +1289,19 @@ impl AssetApi for AssetApiClient {
 
         query_params.insert("asset".to_string(), json!(asset));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = from_symbol {
-            query_params.insert("from_symbol".to_string(), json!(rw));
+            query_params.insert("fromSymbol".to_string(), json!(rw));
         }
 
         if let Some(rw) = to_symbol {
-            query_params.insert("to_symbol".to_string(), json!(rw));
+            query_params.insert("toSymbol".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::UserUniversalTransferResponse>(

--- a/src/wallet/rest_api/apis/capital_api.rs
+++ b/src/wallet/rest_api/apis/capital_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -94,9 +95,6 @@ pub struct AllCoinsInformationParams {
 
 impl AllCoinsInformationParams {
     /// Create a builder for [`all_coins_information`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> AllCoinsInformationParamsBuilder {
@@ -210,9 +208,6 @@ pub struct DepositHistoryParams {
 impl DepositHistoryParams {
     /// Create a builder for [`deposit_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> DepositHistoryParamsBuilder {
         DepositHistoryParamsBuilder::default()
@@ -283,9 +278,6 @@ pub struct OneClickArrivalDepositApplyParams {
 
 impl OneClickArrivalDepositApplyParams {
     /// Create a builder for [`one_click_arrival_deposit_apply`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> OneClickArrivalDepositApplyParamsBuilder {
@@ -434,9 +426,6 @@ pub struct WithdrawHistoryParams {
 impl WithdrawHistoryParams {
     /// Create a builder for [`withdraw_history`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> WithdrawHistoryParamsBuilder {
         WithdrawHistoryParamsBuilder::default()
@@ -454,7 +443,7 @@ impl CapitalApi for CapitalApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::AllCoinsInformationResponseInner>>(
@@ -492,11 +481,12 @@ impl CapitalApi for CapitalApiClient {
         }
 
         if let Some(rw) = amount {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("amount".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::DepositAddressResponse>(
@@ -533,7 +523,7 @@ impl CapitalApi for CapitalApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = include_source {
-            query_params.insert("include_source".to_string(), json!(rw));
+            query_params.insert("includeSource".to_string(), json!(rw));
         }
 
         if let Some(rw) = coin {
@@ -545,11 +535,11 @@ impl CapitalApi for CapitalApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = offset {
@@ -561,11 +551,11 @@ impl CapitalApi for CapitalApiClient {
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         if let Some(rw) = tx_id {
-            query_params.insert("tx_id".to_string(), json!(rw));
+            query_params.insert("txId".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::DepositHistoryResponseInner>>(
@@ -667,19 +657,19 @@ impl CapitalApi for CapitalApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = deposit_id {
-            query_params.insert("deposit_id".to_string(), json!(rw));
+            query_params.insert("depositId".to_string(), json!(rw));
         }
 
         if let Some(rw) = tx_id {
-            query_params.insert("tx_id".to_string(), json!(rw));
+            query_params.insert("txId".to_string(), json!(rw));
         }
 
         if let Some(rw) = sub_account_id {
-            query_params.insert("sub_account_id".to_string(), json!(rw));
+            query_params.insert("subAccountId".to_string(), json!(rw));
         }
 
         if let Some(rw) = sub_user_id {
-            query_params.insert("sub_user_id".to_string(), json!(rw));
+            query_params.insert("subUserId".to_string(), json!(rw));
         }
 
         send_request::<models::OneClickArrivalDepositApplyResponse>(
@@ -720,10 +710,11 @@ impl CapitalApi for CapitalApiClient {
 
         query_params.insert("address".to_string(), json!(address));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         if let Some(rw) = withdraw_order_id {
-            query_params.insert("withdraw_order_id".to_string(), json!(rw));
+            query_params.insert("withdrawOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = network {
@@ -731,11 +722,11 @@ impl CapitalApi for CapitalApiClient {
         }
 
         if let Some(rw) = address_tag {
-            query_params.insert("address_tag".to_string(), json!(rw));
+            query_params.insert("addressTag".to_string(), json!(rw));
         }
 
         if let Some(rw) = transaction_fee_flag {
-            query_params.insert("transaction_fee_flag".to_string(), json!(rw));
+            query_params.insert("transactionFeeFlag".to_string(), json!(rw));
         }
 
         if let Some(rw) = name {
@@ -743,11 +734,11 @@ impl CapitalApi for CapitalApiClient {
         }
 
         if let Some(rw) = wallet_type {
-            query_params.insert("wallet_type".to_string(), json!(rw));
+            query_params.insert("walletType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::WithdrawResponse>(
@@ -788,7 +779,7 @@ impl CapitalApi for CapitalApiClient {
         }
 
         if let Some(rw) = withdraw_order_id {
-            query_params.insert("withdraw_order_id".to_string(), json!(rw));
+            query_params.insert("withdrawOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = status {
@@ -804,19 +795,19 @@ impl CapitalApi for CapitalApiClient {
         }
 
         if let Some(rw) = id_list {
-            query_params.insert("id_list".to_string(), json!(rw));
+            query_params.insert("idList".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::WithdrawHistoryResponseInner>>(

--- a/src/wallet/rest_api/apis/others_api.rs
+++ b/src/wallet/rest_api/apis/others_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -66,9 +67,6 @@ pub struct GetSymbolsDelistScheduleForSpotParams {
 impl GetSymbolsDelistScheduleForSpotParams {
     /// Create a builder for [`get_symbols_delist_schedule_for_spot`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> GetSymbolsDelistScheduleForSpotParamsBuilder {
         GetSymbolsDelistScheduleForSpotParamsBuilder::default()
@@ -87,7 +85,7 @@ impl OthersApi for OthersApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::GetSymbolsDelistScheduleForSpotResponseInner>>(

--- a/src/wallet/rest_api/apis/travel_rule_api.rs
+++ b/src/wallet/rest_api/apis/travel_rule_api.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use derive_builder::Builder;
 use reqwest;
+use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -255,9 +256,6 @@ pub struct DepositHistoryTravelRuleParams {
 impl DepositHistoryTravelRuleParams {
     /// Create a builder for [`deposit_history_travel_rule`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> DepositHistoryTravelRuleParamsBuilder {
         DepositHistoryTravelRuleParamsBuilder::default()
@@ -463,9 +461,6 @@ pub struct WithdrawHistoryV1Params {
 impl WithdrawHistoryV1Params {
     /// Create a builder for [`withdraw_history_v1`].
     ///
-    /// Required parameters:
-    ///
-    ///
     #[must_use]
     pub fn builder() -> WithdrawHistoryV1ParamsBuilder {
         WithdrawHistoryV1ParamsBuilder::default()
@@ -543,9 +538,6 @@ pub struct WithdrawHistoryV2Params {
 
 impl WithdrawHistoryV2Params {
     /// Create a builder for [`withdraw_history_v2`].
-    ///
-    /// Required parameters:
-    ///
     ///
     #[must_use]
     pub fn builder() -> WithdrawHistoryV2ParamsBuilder {
@@ -673,7 +665,8 @@ impl TravelRuleApi for TravelRuleApiClient {
 
         query_params.insert("coin".to_string(), json!(coin));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         query_params.insert("withdrawOrderId".to_string(), json!(withdraw_order_id));
 
@@ -684,7 +677,7 @@ impl TravelRuleApi for TravelRuleApiClient {
         query_params.insert("signature".to_string(), json!(signature));
 
         if let Some(rw) = address_tag {
-            query_params.insert("address_tag".to_string(), json!(rw));
+            query_params.insert("addressTag".to_string(), json!(rw));
         }
 
         if let Some(rw) = network {
@@ -692,15 +685,15 @@ impl TravelRuleApi for TravelRuleApiClient {
         }
 
         if let Some(rw) = address_name {
-            query_params.insert("address_name".to_string(), json!(rw));
+            query_params.insert("addressName".to_string(), json!(rw));
         }
 
         if let Some(rw) = transaction_fee_flag {
-            query_params.insert("transaction_fee_flag".to_string(), json!(rw));
+            query_params.insert("transactionFeeFlag".to_string(), json!(rw));
         }
 
         if let Some(rw) = wallet_type {
-            query_params.insert("wallet_type".to_string(), json!(rw));
+            query_params.insert("walletType".to_string(), json!(rw));
         }
 
         send_request::<models::BrokerWithdrawResponse>(
@@ -739,15 +732,15 @@ impl TravelRuleApi for TravelRuleApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = tr_id {
-            query_params.insert("tr_id".to_string(), json!(rw));
+            query_params.insert("trId".to_string(), json!(rw));
         }
 
         if let Some(rw) = tx_id {
-            query_params.insert("tx_id".to_string(), json!(rw));
+            query_params.insert("txId".to_string(), json!(rw));
         }
 
         if let Some(rw) = tran_id {
-            query_params.insert("tran_id".to_string(), json!(rw));
+            query_params.insert("tranId".to_string(), json!(rw));
         }
 
         if let Some(rw) = network {
@@ -759,19 +752,19 @@ impl TravelRuleApi for TravelRuleApiClient {
         }
 
         if let Some(rw) = travel_rule_status {
-            query_params.insert("travel_rule_status".to_string(), json!(rw));
+            query_params.insert("travelRuleStatus".to_string(), json!(rw));
         }
 
         if let Some(rw) = pending_questionnaire {
-            query_params.insert("pending_questionnaire".to_string(), json!(rw));
+            query_params.insert("pendingQuestionnaire".to_string(), json!(rw));
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = offset {
@@ -876,6 +869,7 @@ impl TravelRuleApi for TravelRuleApiClient {
         }
 
         if let Some(rw) = amount {
+            let rw = Decimal::from_f32(rw).unwrap_or_default();
             query_params.insert("amount".to_string(), json!(rw));
         }
 
@@ -884,7 +878,7 @@ impl TravelRuleApi for TravelRuleApiClient {
         }
 
         if let Some(rw) = address_tag {
-            query_params.insert("address_tag".to_string(), json!(rw));
+            query_params.insert("addressTag".to_string(), json!(rw));
         }
 
         send_request::<models::SubmitDepositQuestionnaireResponse>(
@@ -953,15 +947,15 @@ impl TravelRuleApi for TravelRuleApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = tr_id {
-            query_params.insert("tr_id".to_string(), json!(rw));
+            query_params.insert("trId".to_string(), json!(rw));
         }
 
         if let Some(rw) = tx_id {
-            query_params.insert("tx_id".to_string(), json!(rw));
+            query_params.insert("txId".to_string(), json!(rw));
         }
 
         if let Some(rw) = withdraw_order_id {
-            query_params.insert("withdraw_order_id".to_string(), json!(rw));
+            query_params.insert("withdrawOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = network {
@@ -973,7 +967,7 @@ impl TravelRuleApi for TravelRuleApiClient {
         }
 
         if let Some(rw) = travel_rule_status {
-            query_params.insert("travel_rule_status".to_string(), json!(rw));
+            query_params.insert("travelRuleStatus".to_string(), json!(rw));
         }
 
         if let Some(rw) = offset {
@@ -985,15 +979,15 @@ impl TravelRuleApi for TravelRuleApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::WithdrawHistoryV2ResponseInner>>(
@@ -1032,15 +1026,15 @@ impl TravelRuleApi for TravelRuleApiClient {
         let mut query_params = BTreeMap::new();
 
         if let Some(rw) = tr_id {
-            query_params.insert("tr_id".to_string(), json!(rw));
+            query_params.insert("trId".to_string(), json!(rw));
         }
 
         if let Some(rw) = tx_id {
-            query_params.insert("tx_id".to_string(), json!(rw));
+            query_params.insert("txId".to_string(), json!(rw));
         }
 
         if let Some(rw) = withdraw_order_id {
-            query_params.insert("withdraw_order_id".to_string(), json!(rw));
+            query_params.insert("withdrawOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = network {
@@ -1052,7 +1046,7 @@ impl TravelRuleApi for TravelRuleApiClient {
         }
 
         if let Some(rw) = travel_rule_status {
-            query_params.insert("travel_rule_status".to_string(), json!(rw));
+            query_params.insert("travelRuleStatus".to_string(), json!(rw));
         }
 
         if let Some(rw) = offset {
@@ -1064,15 +1058,15 @@ impl TravelRuleApi for TravelRuleApiClient {
         }
 
         if let Some(rw) = start_time {
-            query_params.insert("start_time".to_string(), json!(rw));
+            query_params.insert("startTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = end_time {
-            query_params.insert("end_time".to_string(), json!(rw));
+            query_params.insert("endTime".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<Vec<models::WithdrawHistoryV2ResponseInner>>(
@@ -1114,12 +1108,13 @@ impl TravelRuleApi for TravelRuleApiClient {
 
         query_params.insert("address".to_string(), json!(address));
 
-        query_params.insert("amount".to_string(), json!(amount));
+        let amount_value = Decimal::from_f32(amount).unwrap_or_default();
+        query_params.insert("amount".to_string(), json!(amount_value));
 
         query_params.insert("questionnaire".to_string(), json!(questionnaire));
 
         if let Some(rw) = withdraw_order_id {
-            query_params.insert("withdraw_order_id".to_string(), json!(rw));
+            query_params.insert("withdrawOrderId".to_string(), json!(rw));
         }
 
         if let Some(rw) = network {
@@ -1127,11 +1122,11 @@ impl TravelRuleApi for TravelRuleApiClient {
         }
 
         if let Some(rw) = address_tag {
-            query_params.insert("address_tag".to_string(), json!(rw));
+            query_params.insert("addressTag".to_string(), json!(rw));
         }
 
         if let Some(rw) = transaction_fee_flag {
-            query_params.insert("transaction_fee_flag".to_string(), json!(rw));
+            query_params.insert("transactionFeeFlag".to_string(), json!(rw));
         }
 
         if let Some(rw) = name {
@@ -1139,11 +1134,11 @@ impl TravelRuleApi for TravelRuleApiClient {
         }
 
         if let Some(rw) = wallet_type {
-            query_params.insert("wallet_type".to_string(), json!(rw));
+            query_params.insert("walletType".to_string(), json!(rw));
         }
 
         if let Some(rw) = recv_window {
-            query_params.insert("recv_window".to_string(), json!(rw));
+            query_params.insert("recvWindow".to_string(), json!(rw));
         }
 
         send_request::<models::WithdrawTravelRuleResponse>(


### PR DESCRIPTION
### Changed (4)

- Made the `count` field required in `WebsocketApiRateLimit`.
- Corrected parameter naming to use camelCase instead of snake_case.
- Resolved floating-point precision issues.
- Fixed serialization of reserved keywords (e.g., `r#type`) so the `r#` prefix is no longer included.