### PR TITLE
chore: upgrade GitHub Actions and fix deprecated commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       modified_targets: ${{ steps.filter.outputs.modified_targets }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2 
 
@@ -44,8 +44,7 @@ jobs:
           MODIFIED_TARGETS_JSON=$(printf '%s\n' "${MODIFIED_TARGETS[@]}" | jq -R -s -c 'split("\n") | map(select(. != ""))')
 
           echo "Detected modified targets: $MODIFIED_TARGETS_JSON"
-          echo "modified_targets=$MODIFIED_TARGETS_JSON" >> $GITHUB_ENV
-          echo "::set-output name=modified_targets::$MODIFIED_TARGETS_JSON"
+          echo "modified_targets=$MODIFIED_TARGETS_JSON" >> $GITHUB_OUTPUT
 
   build-target:
     runs-on: ubuntu-latest
@@ -58,7 +57,7 @@ jobs:
       max-parallel: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Rust ${{ matrix.rust-version }}
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
     
@@ -36,7 +36,7 @@ jobs:
           rustflags: ""
 
       - name: Cache cargo registry & build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
# Summary

This PR simply resolves maintenance issues in GitHub Action CI workflows

# Chores
- Upgrade actions/checkout from v3 to v5 in ci.yaml and release.yaml.
- Upgrade actions/cache from v3 to v4 in release.yaml
- Replace deprecated set-output syntax with GITHUB_OUTPUT in ci.yaml- Remove export variable step for variable modified_targets: [CI uses output variables instead env variable to communicate between jobs](https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/)